### PR TITLE
Grid straddle and generating topography separately

### DIFF
--- a/roms_tools/setup/topography.py
+++ b/roms_tools/setup/topography.py
@@ -42,6 +42,8 @@ def _add_topography_and_mask(ds, topography_source, smooth_factor, hmin, rmax) -
         "units": "meter",
     }
 
+    ds = _add_topography_metadata(ds, topography_source, smooth_factor, hmin, rmax)
+
     return ds
 
 def _make_raw_topography(lon, lat, topography_source) -> np.ndarray:
@@ -193,3 +195,13 @@ def _compute_rfactor(h):
     r_xi = np.abs(h.diff("xi_rho")) / (h + h.shift(xi_rho=1)).isel(xi_rho=slice(1, None))
     
     return r_eta, r_xi
+
+def _add_topography_metadata(ds, topography_source, smooth_factor, hmin, rmax):
+
+    ds.attrs["topography_source"] = topography_source
+    ds.attrs["smooth_factor"] = smooth_factor
+    ds.attrs["hmin"] = hmin
+    ds.attrs["rmax"] = rmax
+
+    return ds
+

--- a/roms_tools/tests/test_setup.py
+++ b/roms_tools/tests/test_setup.py
@@ -49,6 +49,29 @@ class TestCreateGrid:
         )
         assert isinstance(grid, Grid)
 
+    def test_grid_straddle_crosses_meridian(self):
+        grid = Grid(
+            nx=3,
+            ny=3,
+            size_x=100,
+            size_y=100,
+            center_lon=0,
+            center_lat=61,
+            rot=20,
+        )
+        assert grid.straddle == True
+
+        grid = Grid(
+            nx=3,
+            ny=3,
+            size_x=100,
+            size_y=100,
+            center_lon=180,
+            center_lat=61,
+            rot=20,
+        )
+        assert grid.straddle == False
+
 
 class TestGridFromFile:
 


### PR DESCRIPTION
This PR adds two features:
* The `grid.straddle` attribute that indicates whether or not the Greenwhich meridian crosses the domain. This attribute is helpful for interpolation tasks later on.
* The user has now the option to read in a grid from file, but use roms-tools to add the topography. Before this PR, grid generation and topography generation were handled as a single step.
