### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
-    - uses: pre-commit/action@v4.5.0
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v4.5.0

--- a/.github/workflows/pypipublish.yaml
+++ b/.github/workflows/pypipublish.yaml
@@ -38,7 +38,7 @@ jobs:
           git restore -SW .
           python -m build --sdist --wheel .
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: releases
           path: dist
@@ -51,7 +51,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.10'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: releases
           path: dist
@@ -70,14 +70,15 @@ jobs:
     needs: test-built-dist
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: releases
           path: dist
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
-          username: "__token__"
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          verbose: true
+          repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,6 +28,7 @@ jobs:
           environment-file: ci/environment.yml
           create-args: |
             python=${{ matrix.python-version }}
+          cache-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}  # Add a unique cache key
 
       - name: Conda info
         run: conda info


### PR DESCRIPTION
* Upgrade to actions v4
* Migrate to trusted publishers for PyPi (attempts to address #51)
* Use unique cache key per job