### PR TITLE
Integrating `partition` and `.save()`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,8 @@ This python package is strongly inspired by the `UCLA MATLAB tools <https://gith
    Creating initial conditions <initial_conditions>
    Creating boundary forcing <boundary_forcing>
 
+   Partitioning the input files <partition>
+
 .. toctree::
    :maxdepth: 1
    :caption: Community

--- a/docs/partition.ipynb
+++ b/docs/partition.ipynb
@@ -232,7 +232,7 @@
    "id": "e169095c-1b33-4b64-a589-24ae1f9ebe3c",
    "metadata": {},
    "source": [
-    "The previous cell saved the four partitioned datasets to the indicated location:"
+    "The previous cell saved the ten partitioned datasets to the indicated location:"
    ]
   },
   {

--- a/docs/partition.ipynb
+++ b/docs/partition.ipynb
@@ -1,0 +1,335 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ce8e1e7c-bc05-435a-ab05-68e03a5866a4",
+   "metadata": {},
+   "source": [
+    "# Partitioning the input files\n",
+    "\n",
+    "ROMS requires partitioned (or tiled) input files so that the simulation can be parallelized over multiple nodes. `ROMS-Tools` can create these partitioned files for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fd95437d-4fbb-4cf2-b405-c294f1b122e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from roms_tools.utils import partition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60bb804f-c1ad-4a29-9983-016c9ba51921",
+   "metadata": {},
+   "source": [
+    "## Partitioning existing files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fe13d86-db59-4ce3-9a5a-3e5c594012fe",
+   "metadata": {},
+   "source": [
+    "Let's assume we have already saved a global input file to disk, let's call this step 0:\n",
+    "\n",
+    "0. Save global file to disk.\n",
+    "\n",
+    "Here is an example for performing step 0 with `ROMS-Tools` for the grid file. (Note, however, that the `partition` tool does not care whether or whether not `ROMS-Tools` was used to perform step 0.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "71cece64-0143-41e6-b9c8-dc85b97d0bba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from roms_tools import Grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "93596aca-7ee2-4757-8383-bc09267eec6e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "grid = Grid(\n",
+    "    nx=100, ny=100, size_x=1800, size_y=2400, center_lon=-21, center_lat=61, rot=20\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eee45862-2383-4335-896c-de567478aeae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_to_global_file = \"/glade/derecho/scratch/noraloose/examples/my_grid\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "72e1cf7e-226e-4abe-8abe-e39877fbc21b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saving the following file:\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.nc\n"
+     ]
+    }
+   ],
+   "source": [
+    "grid.save(f\"{path_to_global_file}.nc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11a319f2-dcb4-425c-b679-74e38ab66184",
+   "metadata": {},
+   "source": [
+    "We can now partition the saved file as follows:\n",
+    "\n",
+    "1. `xr.open_dataset`: Open saved file as xarray Dataset\n",
+    "2. `partition`: Partition the xarray Dataset into `nx` by `ny` spatial tiles\n",
+    "3. `xr.save_mfdataset`: Save the partitioned xarray Datasets to file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b6e30499-935a-4078-895c-b0e4cd0b1920",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "16a35ce0-9ef6-49b5-8230-46f99dc4709f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(f\"{path_to_global_file}.nc\")  # step 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7081fa77-2af5-4642-b879-29c827f3efc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_numbers, partitioned_datasets = partition(ds, nx=2, ny=5)  # step 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "811cc34e-e913-4526-a062-b8b6eba5aede",
+   "metadata": {},
+   "source": [
+    "The previous cell returns two lists:\n",
+    "* `file_numbers` is a list of integers representing the file numbers associated with each partitioned dataset\n",
+    "* `partitioned_datasets` is a list of `xarray.Dataset` objects, each representing a partitioned subdomain of the original dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "946a5e67-1328-4a3c-8931-634718cd7a63",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "file_numbers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2e0e743-c08c-49ad-97c4-f36586ca9906",
+   "metadata": {},
+   "source": [
+    "For the third step, we have to create a list of paths to which to save each corresponding dataset. This is where the list `file_numbers` comes in handy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ab26dd1f-43ec-45f6-b7ac-eb3bc038ffa4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "paths_to_partitioned_files = [\n",
+    "    f\"{path_to_global_file}.{file_number}.nc\" for file_number in file_numbers\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "aa90976d-29d3-480c-84df-2c91f8aa5bd4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['/glade/derecho/scratch/noraloose/examples/my_grid.0.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.1.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.2.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.3.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.4.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.5.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.6.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.7.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.8.nc',\n",
+       " '/glade/derecho/scratch/noraloose/examples/my_grid.9.nc']"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "paths_to_partitioned_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "4d103aa2-6fab-4e1a-97a8-1f1a3fbfd193",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xr.save_mfdataset(partitioned_datasets, paths_to_partitioned_files)  # step 3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e169095c-1b33-4b64-a589-24ae1f9ebe3c",
+   "metadata": {},
+   "source": [
+    "The previous cell saved the four partitioned datasets to the indicated location:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "77863475-d447-46cb-a619-89960c1d92a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my_grid.0.nc  my_grid.3.nc  my_grid.6.nc  my_grid.9.nc\n",
+      "my_grid.1.nc  my_grid.4.nc  my_grid.7.nc  my_grid.nc\n",
+      "my_grid.2.nc  my_grid.5.nc  my_grid.8.nc\n"
+     ]
+    }
+   ],
+   "source": [
+    "ls /glade/derecho/scratch/noraloose/examples/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "710fee39-f7e3-42ec-a626-b07ffeeb5e72",
+   "metadata": {},
+   "source": [
+    "## Creating partitioned files directly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42d95865-b527-44d5-a3dd-cf7bc7ccdf70",
+   "metadata": {},
+   "source": [
+    "Instead of manually going through steps 0, 1, 2, 3 above, we can also tell `ROMS-Tools` to write partitioned files directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ca08a3a8-719f-4f64-942a-234d0064400d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid = Grid(\n",
+    "    nx=100, ny=100, size_x=1800, size_y=2400, center_lon=-21, center_lat=61, rot=20\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "45cf6192-e13f-401f-9c78-ad23e00b1473",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Saving the following files:\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.0.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.1.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.2.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.3.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.4.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.5.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.6.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.7.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.8.nc\n",
+      "/glade/derecho/scratch/noraloose/grids/my_grid.9.nc\n"
+     ]
+    }
+   ],
+   "source": [
+    "grid.save(filepath=\"/glade/derecho/scratch/noraloose/grids/my_grid\", nx=2, ny=5)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:romstools]",
+   "language": "python",
+   "name": "conda-env-romstools-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/partition.ipynb
+++ b/docs/partition.ipynb
@@ -141,6 +141,7 @@
    "metadata": {},
    "source": [
     "The previous cell returns two lists:\n",
+    "\n",
     "* `file_numbers` is a list of integers representing the file numbers associated with each partitioned dataset\n",
     "* `partitioned_datasets` is a list of `xarray.Dataset` objects, each representing a partitioned subdomain of the original dataset"
    ]

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -12,6 +12,7 @@ from roms_tools.setup.plot import _plot, _section_plot, _profile_plot, _line_plo
 from roms_tools.setup.utils import interpolate_from_rho_to_u, interpolate_from_rho_to_v
 from roms_tools.setup.vertical_coordinate import sigma_stretch, compute_depth
 from roms_tools.setup.utils import extract_single_value
+from roms_tools.utils import partition
 import warnings
 
 RADIUS_OF_EARTH = 6371315.0  # in m
@@ -515,15 +516,52 @@ class Grid:
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: str) -> None:
+    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
         """
         Save the grid information to a netCDF4 file.
 
+        This method supports saving the dataset in two modes:
+
+        1. **Single File Mode (default)**:
+           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath`.
+
+        2. **Partitioned Mode**:
+           - If either `nx` or `ny` is provided, the dataset is divided into `nx` by `ny` spatial tiles and each tile is saved as a separate file.
+           - The files are saved as `filepath.0.nc`, `filepath.1.nc`, ..., where the numbering corresponds to the partition index.
+
         Parameters
         ----------
-        filepath
+        filepath : str
+            The base path or filename where the dataset should be saved.
+        nx : int, optional
+            The number of partitions along the x-axis. If `None`, no partitioning is done.
+        ny : int, optional
+            The number of partitions along the y-axis. If `None`, no partitioning is done.
+
+        Returns
+        -------
+        None
         """
-        self.ds.to_netcdf(filepath)
+
+        if nx is None and ny is None:
+            print("Saving the following file:")
+            print(filepath)
+            self.ds.to_netcdf(filepath)
+        else:
+            nx = nx or 1
+            ny = ny or 1
+
+            file_numbers, partitioned_datasets = partition(self.ds, nx=nx, ny=ny)
+
+            paths_to_partitioned_files = [
+                f"{filepath}.{file_number}.nc" for file_number in file_numbers
+            ]
+
+            print("Saving the following files:")
+            for path in paths_to_partitioned_files:
+                print(path)
+
+            xr.save_mfdataset(partitioned_datasets, paths_to_partitioned_files)
 
     @classmethod
     def from_file(cls, filepath: str) -> "Grid":

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -14,6 +14,7 @@ from roms_tools.setup.utils import (
 )
 from roms_tools.setup.mixins import ROMSToolsMixins
 from roms_tools.setup.plot import _plot, _section_plot, _profile_plot, _line_plot
+from roms_tools.utils import partition
 import matplotlib.pyplot as plt
 
 
@@ -481,15 +482,52 @@ class InitialConditions(ROMSToolsMixins):
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: str) -> None:
+    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
         """
         Save the initial conditions information to a netCDF4 file.
 
+        This method supports saving the dataset in two modes:
+
+        1. **Single File Mode (default)**:
+           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath`.
+
+        2. **Partitioned Mode**:
+           - If either `nx` or `ny` is provided, the dataset is divided into `nx` by `ny` spatial tiles and each tile is saved as a separate file.
+           - The files are saved as `filepath.0.nc`, `filepath.1.nc`, ..., where the numbering corresponds to the partition index.
+
         Parameters
         ----------
-        filepath
+        filepath : str
+            The base path or filename where the dataset should be saved.
+        nx : int, optional
+            The number of partitions along the x-axis. If `None`, no partitioning is done.
+        ny : int, optional
+            The number of partitions along the y-axis. If `None`, no partitioning is done.
+
+        Returns
+        -------
+        None
         """
-        self.ds.to_netcdf(filepath)
+
+        if nx is None and ny is None:
+            print("Saving the following file:")
+            print(filepath)
+            self.ds.to_netcdf(filepath)
+        else:
+            nx = nx or 1
+            ny = ny or 1
+
+            file_numbers, partitioned_datasets = partition(self.ds, nx=nx, ny=ny)
+
+            paths_to_partitioned_files = [
+                f"{filepath}.{file_number}.nc" for file_number in file_numbers
+            ]
+
+            print("Saving the following files:")
+            for path in paths_to_partitioned_files:
+                print(path)
+
+            xr.save_mfdataset(partitioned_datasets, paths_to_partitioned_files)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -1,6 +1,5 @@
 import xarray as xr
 import pandas as pd
-import dask
 import yaml
 import importlib.metadata
 from dataclasses import dataclass, field, asdict
@@ -21,6 +20,7 @@ from roms_tools.setup.utils import (
     get_variable_metadata,
 )
 from roms_tools.setup.plot import _plot
+from roms_tools.utils import partition
 import calendar
 import matplotlib.pyplot as plt
 
@@ -409,77 +409,106 @@ class SurfaceForcing(ROMSToolsMixins):
             c="g",
         )
 
-    def save(self, filepath: str, time_chunk_size: int = 1) -> None:
+    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
         """
         Save the interpolated surface forcing fields to netCDF4 files.
 
-        This method groups the dataset by year and month, chunks the data by the specified
-        time chunk size, and saves each chunked subset to a separate netCDF4 file named
-        according to the year, month, and day range if not a complete month of data is included.
+        This method saves the dataset by grouping it into yearly and monthly subsets. Each subset is then written to one or more netCDF4 files.
+        The filenames of the output files reflect the temporal coverage of the data.
+
+        There are two modes of saving the dataset:
+
+        1. **Single File Mode (default)**:
+           - If both `nx` and `ny` are `None`, the entire dataset, divided by temporal subsets, is saved as a single netCDF4 file
+             with the base filename specified by `filepath`. The file names will follow the format:
+             - `"filepath_YYYYMM.nc"` for complete months of data
+             - `"filepath_YYYYMMDD-DD.nc"` for partial months of data
+
+        2. **Partitioned Mode**:
+           - If either `nx` or `ny` is specified, the dataset is divided into spatial tiles along the x-axis and y-axis.
+             Each spatial tile is saved as a separate netCDF4 file. In this case, filenames include a partition index:
+             - `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc. for full month files
+             - `"filepath_YYYYMMDD-DD.0.nc"`, `"filepath_YYYYMMDD-DD.1.nc"`, etc. for partial month files
 
         Parameters
         ----------
         filepath : str
-            The base path and filename for the output files. The files will be named with
-            the format "filepath.YYYYMM.nc" if a full month of data is included, or
-            "filepath.YYYYMMDD-DD.nc" otherwise.
-        time_chunk_size : int, optional
-            Number of time slices to include in each chunk along the time dimension. Default is 1,
-            meaning each chunk contains one time slice.
+            The base path and filename for the output files. The format of the filenames depends on whether partitioning is used
+            and the temporal range of the data. For partitioned datasets, files will be named with an additional index, e.g.,
+            `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc.
+        nx : int, optional
+            The number of partitions along the x-axis. If `None`, no spatial partitioning is performed.
+        ny : int, optional
+            The number of partitions along the y-axis. If `None`, no spatial partitioning is performed.
 
         Returns
         -------
         None
+            This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        datasets = []
-        filenames = []
-        writes = []
+        dataset_list = []
+        output_filenames = []
 
         if hasattr(self.ds, "climatology"):
-            filename = f"{filepath}_clim.nc"
-            filenames.append(filename)
-            datasets.append(self.ds)
+            output_filename = f"{filepath}_clim"
+            output_filenames.append(output_filename)
+            dataset_list.append(self.ds)
         else:
             # Group dataset by year
-            gb = self.ds.groupby("abs_time.year")
+            grouped_by_year = self.ds.groupby("abs_time.year")
 
-            for year, group_ds in gb:
+            for year, yearly_dataset in grouped_by_year:
                 # Further group each yearly group by month
-                sub_gb = group_ds.groupby("abs_time.month")
+                grouped_by_month = yearly_dataset.groupby("abs_time.month")
 
-                for month, ds in sub_gb:
-                    # Chunk the dataset by the specified time chunk size
-                    ds = ds.chunk({"time": time_chunk_size})
-                    datasets.append(ds)
+                for month, monthly_dataset in grouped_by_month:
+                    dataset_list.append(monthly_dataset)
 
                     # Determine the number of days in the month
-                    num_days_in_month = calendar.monthrange(year, month)[1]
-                    first_day = ds.abs_time.dt.day.values[0]
-                    last_day = ds.abs_time.dt.day.values[-1]
+                    days_in_month = calendar.monthrange(year, month)[1]
+                    first_day = monthly_dataset.abs_time.dt.day.values[0]
+                    last_day = monthly_dataset.abs_time.dt.day.values[-1]
 
                     # Create filename based on whether the dataset contains a full month
-                    if first_day == 1 and last_day == num_days_in_month:
-                        # Full month format: "filepath_YYYYMM.nc"
+                    if first_day == 1 and last_day == days_in_month:
+                        # Full month format: "filepath_physics_YYYYMM.nc"
                         year_month_str = f"{year}{month:02}"
-                        filename = f"{filepath}_{year_month_str}.nc"
+                        output_filename = f"{filepath}_{year_month_str}"
                     else:
-                        # Partial month format: "filepath_YYYYMMDD-DD.nc"
+                        # Partial month format: "filepath_physics_YYYYMMDD-DD.nc"
                         year_month_day_str = (
                             f"{year}{month:02}{first_day:02}-{last_day:02}"
                         )
-                        filename = f"{filepath}_{year_month_day_str}.nc"
-                    filenames.append(filename)
+                        output_filename = f"{filepath}_{year_month_day_str}"
+                    output_filenames.append(output_filename)
 
         print("Saving the following files:")
-        for ds, filename in zip(datasets, filenames):
-            print(filename)
-            # Prepare the dataset for writing to a netCDF file without immediately computing
-            write = ds.to_netcdf(filename, compute=False)
-            writes.append(write)
+        if nx is None and ny is None:
+            # Save the dataset as a single file
+            output_filenames = [f"{filename}.nc" for filename in output_filenames]
+            for filename in output_filenames:
+                print(filename)
+            xr.save_mfdataset(dataset_list, output_filenames)
+        else:
+            # Partition the dataset and save each partition as a separate file
+            nx = nx or 1
+            ny = ny or 1
 
-        # Perform the actual write operations in parallel
-        dask.compute(*writes)
+            partitioned_datasets = []
+            partitioned_filenames = []
+            for dataset, base_filename in zip(dataset_list, output_filenames):
+                partition_indices, partitions = partition(dataset, nx=nx, ny=ny)
+                partition_filenames = [
+                    f"{base_filename}.{index}.nc" for index in partition_indices
+                ]
+                partitioned_datasets.extend(partitions)
+                partitioned_filenames.extend(partition_filenames)
+
+            for filename in partitioned_filenames:
+                print(filename)
+
+            xr.save_mfdataset(partitioned_datasets, partitioned_filenames)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/tests/test_setup/test_boundary_forcing.py
+++ b/roms_tools/tests/test_setup/test_boundary_forcing.py
@@ -109,8 +109,20 @@ def test_boundary_forcing_plot_save(
     finally:
         os.remove(extended_filepath)
 
+    boundary_forcing.save(filepath, nx=2)
+    expected_filepath_list = [
+        f"{filepath}_20210629-29.{index}.nc" for index in range(2)
+    ]
 
-def test_bgc_boundary_forcing_data_consistency_plot_save(
+    try:
+        for expected_filepath in expected_filepath_list:
+            assert os.path.exists(expected_filepath)
+    finally:
+        for expected_filepath in expected_filepath_list:
+            os.remove(expected_filepath)
+
+
+def test_bgc_boundary_forcing_plot_save(
     bgc_boundary_forcing_from_climatology,
 ):
     """
@@ -133,6 +145,16 @@ def test_bgc_boundary_forcing_data_consistency_plot_save(
         assert os.path.exists(extended_filepath)
     finally:
         os.remove(extended_filepath)
+
+    bgc_boundary_forcing_from_climatology.save(filepath, ny=2)
+    expected_filepath_list = [f"{filepath}_clim.{index}.nc" for index in range(2)]
+
+    try:
+        for expected_filepath in expected_filepath_list:
+            assert os.path.exists(expected_filepath)
+    finally:
+        for expected_filepath in expected_filepath_list:
+            os.remove(expected_filepath)
 
 
 @pytest.mark.parametrize(

--- a/roms_tools/tests/test_setup/test_grid.py
+++ b/roms_tools/tests/test_setup/test_grid.py
@@ -20,12 +20,29 @@ def test_grid_creation(grid):
     assert isinstance(grid.ds, xr.Dataset)
 
 
-def test_plot_save_methods(grid, tmp_path):
+def test_plot_save_methods():
+
+    grid = Grid(
+        nx=20, ny=20, size_x=100, size_y=100, center_lon=-20, center_lat=0, rot=0
+    )
 
     grid.plot(bathymetry=True)
-    filepath = tmp_path / "grid.nc"
+    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
+        filepath = tmpfile.name
     grid.save(filepath)
-    assert filepath.exists()
+    try:
+        assert os.path.exists(filepath)
+    finally:
+        os.remove(filepath)
+
+    grid.save(filepath, nx=2, ny=5)
+    expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(10)]
+    try:
+        for expected_filepath in expected_filepath_list:
+            assert os.path.exists(expected_filepath)
+    finally:
+        for expected_filepath in expected_filepath_list:
+            os.remove(expected_filepath)
 
 
 def test_raise_if_domain_too_large():

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -162,9 +162,7 @@ def test_interpolation_from_climatology(initial_conditions_with_bgc_from_climato
     )
 
 
-def test_initial_conditions_plot_save(
-    initial_conditions_with_bgc_from_climatology, tmp_path
-):
+def test_initial_conditions_plot_save(initial_conditions_with_bgc_from_climatology):
     """
     Test plot and save methods.
     """
@@ -201,9 +199,24 @@ def test_initial_conditions_plot_save(
     initial_conditions_with_bgc_from_climatology.plot(varname="ALK", s=0, xi=0)
     initial_conditions_with_bgc_from_climatology.plot(varname="ALK", eta=0, xi=0)
 
-    filepath = tmp_path / "initial_conditions.nc"
+    # Create a temporary file
+    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
+        filepath = tmpfile.name
     initial_conditions_with_bgc_from_climatology.save(filepath)
-    assert filepath.exists()
+    try:
+        assert os.path.exists(filepath)
+    finally:
+        os.remove(filepath)
+
+    initial_conditions_with_bgc_from_climatology.save(filepath, nx=2)
+    expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(2)]
+
+    try:
+        for expected_filepath in expected_filepath_list:
+            assert os.path.exists(expected_filepath)
+    finally:
+        for expected_filepath in expected_filepath_list:
+            os.remove(expected_filepath)
 
 
 def test_roundtrip_yaml(initial_conditions):

--- a/roms_tools/tests/test_setup/test_surface_forcing.py
+++ b/roms_tools/tests/test_setup/test_surface_forcing.py
@@ -501,6 +501,18 @@ def test_surface_forcing_plot_save(sfc_forcing_fixture, request, tmp_path):
     finally:
         os.remove(extended_filepath)
 
+    sfc_forcing.save(filepath, nx=1)
+    expected_filepath_list = [
+        f"{filepath}_20200201-01.{index}.nc" for index in range(1)
+    ]
+
+    try:
+        for expected_filepath in expected_filepath_list:
+            assert os.path.exists(expected_filepath)
+    finally:
+        for expected_filepath in expected_filepath_list:
+            os.remove(expected_filepath)
+
 
 def test_surface_forcing_bgc_plot_save(
     bgc_surface_forcing,
@@ -523,6 +535,18 @@ def test_surface_forcing_bgc_plot_save(
         assert os.path.exists(extended_filepath)
     finally:
         os.remove(extended_filepath)
+
+    bgc_surface_forcing.save(filepath, ny=5)
+    expected_filepath_list = [
+        f"{filepath}_20200201-01.{index}.nc" for index in range(5)
+    ]
+
+    try:
+        for expected_filepath in expected_filepath_list:
+            assert os.path.exists(expected_filepath)
+    finally:
+        for expected_filepath in expected_filepath_list:
+            os.remove(expected_filepath)
 
 
 def test_surface_forcing_bgc_from_clim_plot_save(
@@ -547,6 +571,16 @@ def test_surface_forcing_bgc_from_clim_plot_save(
         assert os.path.exists(extended_filepath)
     finally:
         os.remove(extended_filepath)
+
+    bgc_surface_forcing_from_climatology.save(filepath, nx=5)
+    expected_filepath_list = [f"{filepath}_clim.{index}.nc" for index in range(5)]
+
+    try:
+        for expected_filepath in expected_filepath_list:
+            assert os.path.exists(expected_filepath)
+    finally:
+        for expected_filepath in expected_filepath_list:
+            os.remove(expected_filepath)
 
 
 @pytest.mark.parametrize(

--- a/roms_tools/tests/test_setup/test_tides.py
+++ b/roms_tools/tests/test_setup/test_tides.py
@@ -184,6 +184,16 @@ def test_tidal_forcing_plot_save(tidal_forcing, tmp_path):
     finally:
         os.remove(filepath)
 
+    tidal_forcing.save(filepath, nx=3, ny=3)
+    expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(9)]
+
+    try:
+        for expected_filepath in expected_filepath_list:
+            assert os.path.exists(expected_filepath)
+    finally:
+        for expected_filepath in expected_filepath_list:
+            os.remove(expected_filepath)
+
 
 def test_roundtrip_yaml(tidal_forcing):
     """Test that creating a TidalForcing object, saving its parameters to yaml file, and re-opening yaml file creates the same object."""

--- a/roms_tools/tests/test_utils.py
+++ b/roms_tools/tests/test_utils.py
@@ -194,7 +194,7 @@ class TestPartitionGrid:
         with pytest.raises(ValueError, match="nx and ny must be positive integers"):
             partition(grid.ds, nx=-3, ny=1)
 
-        with pytest.raises(ValueError, match="does not divide the domain"):
+        with pytest.raises(ValueError, match="cannot be evenly divided"):
             partition(grid.ds, nx=4, ny=1)
 
 

--- a/roms_tools/tests/test_utils.py
+++ b/roms_tools/tests/test_utils.py
@@ -217,3 +217,16 @@ class TestPartitionMissingDims:
         _, partitioned_datasets = partition(ds_missing_dims, nx=1, ny=1)
 
         xrt.assert_identical(partitioned_datasets[0], ds_missing_dims)
+
+
+class TestFileNumbers:
+    def test_partition_file_numbers(self, grid):
+        nx = 3
+        ny = 5
+        file_numbers, _ = partition(grid.ds, nx=nx, ny=ny)
+
+        # Generate the expected file numbers
+        expected_file_numbers = list(range(nx * ny))
+
+        # Check if file_numbers is a continuous range without gaps
+        assert file_numbers == expected_file_numbers

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -78,40 +78,63 @@ def partition(
     else:
         n_xi_ghost_cells = 1
 
-    def integer_division_or_raise(a: int, b: int) -> int:
+    def integer_division_or_raise(a: int, b: int, dimension: str) -> int:
+        """
+        Perform integer division and ensure that the division is exact.
+
+        Parameters
+        ----------
+        a : int
+            The numerator for the division.
+        b : int
+            The denominator for the division.
+        dimension : str
+            The name of the dimension being partitioned, used for error reporting.
+
+        Returns
+        -------
+        int
+            The result of the integer division.
+
+        Raises
+        ------
+        ValueError
+            If the division is not exact, indicating that the domain cannot be evenly divided
+            along the specified dimension.
+        """
         remainder = a % b
         if remainder == 0:
             return a // b
         else:
             raise ValueError(
-                f"Partitioning nx = {nx} ny = {ny} does not divide the domain into subdomains of integer size."
+                f"Dimension '{dimension}' of size {a} cannot be evenly divided into {b} partitions."
             )
 
     if "eta_rho" in dims_to_partition:
         eta_rho_domain_size = integer_division_or_raise(
-            ds.sizes["eta_rho"] - 2 * n_eta_ghost_cells, nx
+            ds.sizes["eta_rho"] - 2 * n_eta_ghost_cells, nx, "eta_rho"
         )
     if "xi_rho" in dims_to_partition:
         xi_rho_domain_size = integer_division_or_raise(
-            ds.sizes["xi_rho"] - 2 * n_xi_ghost_cells, ny
+            ds.sizes["xi_rho"] - 2 * n_xi_ghost_cells, ny, "xi_rho"
         )
 
     if "eta_v" in dims_to_partition:
         eta_v_domain_size = integer_division_or_raise(
-            ds.sizes["eta_v"] - 1 * n_eta_ghost_cells, nx
+            ds.sizes["eta_v"] - 1 * n_eta_ghost_cells, nx, "eta_v"
         )
     if "xi_u" in dims_to_partition:
         xi_u_domain_size = integer_division_or_raise(
-            ds.sizes["xi_u"] - 1 * n_xi_ghost_cells, ny
+            ds.sizes["xi_u"] - 1 * n_xi_ghost_cells, ny, "xi_u"
         )
 
     if "eta_coarse" in dims_to_partition:
         eta_coarse_domain_size = integer_division_or_raise(
-            ds.sizes["eta_coarse"] - 2 * n_eta_ghost_cells, nx
+            ds.sizes["eta_coarse"] - 2 * n_eta_ghost_cells, nx, "eta_coarse"
         )
     if "xi_coarse" in dims_to_partition:
         xi_coarse_domain_size = integer_division_or_raise(
-            ds.sizes["xi_coarse"] - 2 * n_xi_ghost_cells, ny
+            ds.sizes["xi_coarse"] - 2 * n_xi_ghost_cells, ny, "xi_coarse"
         )
 
     # unpartitioned dimensions should have sizes unchanged

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -187,12 +187,11 @@ def partition(
         np.cumsum(pmf, out=cdf[1:])
         return cdf
 
-    file_numbers = []
+    file_numbers = [i + j * nx for j in range(ny) for i in range(nx)]
     partitioned_datasets = []
+
     for j in range(ny):
         for i in range(nx):
-            file_number = i + (j * ny)
-            file_numbers.append(file_number)
 
             indexers = {}
 

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -8,7 +8,48 @@ def partition(
     ds: xr.Dataset, nx: int = 1, ny: int = 1
 ) -> tuple[list[int], list[xr.Dataset]]:
     """
-    Split a ROMS dataset up into nx by ny spatial tiles.
+    Partition a ROMS (Regional Ocean Modeling System) dataset into smaller spatial tiles.
+
+    This function divides the input dataset into `nx` by `ny` tiles, where each tile
+    represents a subdomain of the original dataset. The partitioning is performed along
+    the spatial dimensions `eta_rho`, `xi_rho`, `eta_v`, `xi_u`, `eta_coarse`, and `xi_coarse`,
+    depending on which dimensions are present in the dataset.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The input ROMS dataset that is to be partitioned.
+
+    nx : int, optional
+        The number of partitions along the `eta` (latitude) direction. Must be a positive integer. Default is 1.
+
+    ny : int, optional
+        The number of partitions along the `xi` (longitude) direction. Must be a positive integer. Default is 1.
+
+    Returns
+    -------
+    tuple[list[int], list[xr.Dataset]]
+        A tuple containing two elements:
+        - A list of integers representing the file numbers associated with each partition.
+        - A list of `xarray.Dataset` objects, each representing a partitioned subdomain of the original dataset.
+
+    Raises
+    ------
+    ValueError
+        If `nx` or `ny` is not a positive integer, or if the dataset cannot be evenly partitioned
+        into the specified number of tiles.
+
+
+    Example
+    -------
+    >>> partitioned_file_numbers, partitioned_datasets = partition(ds, nx=2, ny=3)
+    >>> print(partitioned_file_numbers)
+    [0, 1, 2, 3, 4, 5]
+    >>> print([ds.sizes for ds in partitioned_datasets])
+    [{'eta_rho': 50, 'xi_rho': 50}, {'eta_rho': 50, 'xi_rho': 50}, ...]
+
+    This example partitions the dataset into 2 tiles along the `eta` direction and 3 tiles
+    along the `xi` direction, resulting in a total of 6 partitions.
     """
 
     if not isinstance(nx, Integral) or nx < 1 or not isinstance(ny, Integral) or ny < 1:

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -187,11 +187,12 @@ def partition(
         np.cumsum(pmf, out=cdf[1:])
         return cdf
 
-    file_numbers = [i + j * nx for j in range(ny) for i in range(nx)]
+    file_numbers = []
     partitioned_datasets = []
-
     for j in range(ny):
         for i in range(nx):
+            file_number = i + (j * nx)
+            file_numbers.append(file_number)
 
             indexers = {}
 


### PR DESCRIPTION
This PR is a follow-up of #101. It
* fixes a small bug that made `partition` return the wrong `file_numbers`
* integrates `partition` with the `.save()` methods
* adds some examples of how to use `partition` to the documentation