### PR TITLE
Improved filenames

### DIFF
--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -501,6 +501,9 @@ class BoundaryForcing(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
+        if filepath.endswith(".nc"):
+            filepath = filepath[:-3]
+
         dataset_list = []
         output_filenames = []
 
@@ -526,11 +529,11 @@ class BoundaryForcing(ROMSToolsMixins):
 
                     # Create filename based on whether the dataset contains a full month
                     if first_day == 1 and last_day == days_in_month:
-                        # Full month format: "filepath_physics_YYYYMM.nc"
+                        # Full month format: "filepath_physics_YYYYMM"
                         year_month_str = f"{year}{month:02}"
                         output_filename = f"{filepath}_{year_month_str}"
                     else:
-                        # Partial month format: "filepath_physics_YYYYMMDD-DD.nc"
+                        # Partial month format: "filepath_physics_YYYYMMDD-DD"
                         year_month_day_str = (
                             f"{year}{month:02}{first_day:02}-{last_day:02}"
                         )

--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -14,10 +14,10 @@ from roms_tools.setup.utils import (
     substitute_nans_by_fillvalue,
     get_variable_metadata,
     get_boundary_info,
+    group_dataset,
+    save_datasets,
 )
 from roms_tools.setup.plot import _section_plot, _line_plot
-from roms_tools.utils import partition
-import calendar
 import matplotlib.pyplot as plt
 
 
@@ -465,24 +465,20 @@ class BoundaryForcing(ROMSToolsMixins):
 
     def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
         """
-        Save the interpolated boundary forcing fields to netCDF4 files.
+        Save the boundary forcing fields to netCDF4 files.
 
-        This method saves the dataset by grouping it into yearly and monthly subsets. Each subset is then written to one or more netCDF4 files.
-        The filenames of the output files reflect the temporal coverage of the data.
+        This method saves the dataset by grouping it into subsets based on the data frequency. The subsets are then written
+        to one or more netCDF4 files. The filenames of the output files reflect the temporal coverage of the data.
 
         There are two modes of saving the dataset:
 
         1. **Single File Mode (default)**:
            - If both `nx` and `ny` are `None`, the entire dataset, divided by temporal subsets, is saved as a single netCDF4 file
-             with the base filename specified by `filepath`. The file names will follow the format:
-             - `"filepath_YYYYMM.nc"` for complete months of data
-             - `"filepath_YYYYMMDD-DD.nc"` for partial months of data
+             with the base filename specified by `filepath.nc`.
 
         2. **Partitioned Mode**:
            - If either `nx` or `ny` is specified, the dataset is divided into spatial tiles along the x-axis and y-axis.
-             Each spatial tile is saved as a separate netCDF4 file. In this case, filenames include a partition index:
-             - `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc. for full month files
-             - `"filepath_YYYYMMDD-DD.0.nc"`, `"filepath_YYYYMMDD-DD.1.nc"`, etc. for partial month files
+             Each spatial tile is saved as a separate netCDF4 file.
 
         Parameters
         ----------
@@ -504,68 +500,8 @@ class BoundaryForcing(ROMSToolsMixins):
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        dataset_list = []
-        output_filenames = []
-
-        if hasattr(self.ds, "climatology"):
-            output_filename = f"{filepath}_clim"
-            output_filenames.append(output_filename)
-            dataset_list.append(self.ds)
-        else:
-            # Group dataset by year
-            grouped_by_year = self.ds.groupby("abs_time.year")
-
-            for year, yearly_dataset in grouped_by_year:
-                # Further group each yearly group by month
-                grouped_by_month = yearly_dataset.groupby("abs_time.month")
-
-                for month, monthly_dataset in grouped_by_month:
-                    dataset_list.append(monthly_dataset)
-
-                    # Determine the number of days in the month
-                    days_in_month = calendar.monthrange(year, month)[1]
-                    first_day = monthly_dataset.abs_time.dt.day.values[0]
-                    last_day = monthly_dataset.abs_time.dt.day.values[-1]
-
-                    # Create filename based on whether the dataset contains a full month
-                    if first_day == 1 and last_day == days_in_month:
-                        # Full month format: "filepath_physics_YYYYMM"
-                        year_month_str = f"{year}{month:02}"
-                        output_filename = f"{filepath}_{year_month_str}"
-                    else:
-                        # Partial month format: "filepath_physics_YYYYMMDD-DD"
-                        year_month_day_str = (
-                            f"{year}{month:02}{first_day:02}-{last_day:02}"
-                        )
-                        output_filename = f"{filepath}_{year_month_day_str}"
-                    output_filenames.append(output_filename)
-
-        print("Saving the following files:")
-        if nx is None and ny is None:
-            # Save the dataset as a single file
-            output_filenames = [f"{filename}.nc" for filename in output_filenames]
-            for filename in output_filenames:
-                print(filename)
-            xr.save_mfdataset(dataset_list, output_filenames)
-        else:
-            # Partition the dataset and save each partition as a separate file
-            nx = nx or 1
-            ny = ny or 1
-
-            partitioned_datasets = []
-            partitioned_filenames = []
-            for dataset, base_filename in zip(dataset_list, output_filenames):
-                partition_indices, partitions = partition(dataset, nx=nx, ny=ny)
-                partition_filenames = [
-                    f"{base_filename}.{index}.nc" for index in partition_indices
-                ]
-                partitioned_datasets.extend(partitions)
-                partitioned_filenames.extend(partition_filenames)
-
-            for filename in partitioned_filenames:
-                print(filename)
-
-            xr.save_mfdataset(partitioned_datasets, partitioned_filenames)
+        dataset_list, output_filenames = group_dataset(self.ds, filepath)
+        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -543,6 +543,9 @@ class Grid:
         None
         """
 
+        if filepath.endswith(".nc"):
+            filepath = filepath[:-3]
+
         if nx is None and ny is None:
             print("Saving the following file:")
             print(filepath)

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -11,8 +11,7 @@ from roms_tools.setup.topography import _add_topography_and_mask, _add_velocity_
 from roms_tools.setup.plot import _plot, _section_plot, _profile_plot, _line_plot
 from roms_tools.setup.utils import interpolate_from_rho_to_u, interpolate_from_rho_to_v
 from roms_tools.setup.vertical_coordinate import sigma_stretch, compute_depth
-from roms_tools.setup.utils import extract_single_value
-from roms_tools.utils import partition
+from roms_tools.setup.utils import extract_single_value, save_datasets
 import warnings
 
 RADIUS_OF_EARTH = 6371315.0  # in m
@@ -523,7 +522,7 @@ class Grid:
         This method supports saving the dataset in two modes:
 
         1. **Single File Mode (default)**:
-           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath`.
+           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
 
         2. **Partitioned Mode**:
            - If either `nx` or `ny` is provided, the dataset is divided into `nx` by `ny` spatial tiles and each tile is saved as a separate file.
@@ -541,30 +540,16 @@ class Grid:
         Returns
         -------
         None
+            This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        if nx is None and ny is None:
-            print("Saving the following file:")
-            print(filepath)
-            self.ds.to_netcdf(filepath)
-        else:
-            nx = nx or 1
-            ny = ny or 1
+        dataset_list = [self.ds]
+        output_filenames = [filepath]
 
-            file_numbers, partitioned_datasets = partition(self.ds, nx=nx, ny=ny)
-
-            paths_to_partitioned_files = [
-                f"{filepath}.{file_number}.nc" for file_number in file_numbers
-            ]
-
-            print("Saving the following files:")
-            for path in paths_to_partitioned_files:
-                print(path)
-
-            xr.save_mfdataset(partitioned_datasets, paths_to_partitioned_files)
+        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     @classmethod
     def from_file(cls, filepath: str) -> "Grid":

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -11,10 +11,10 @@ from roms_tools.setup.utils import (
     nan_check,
     substitute_nans_by_fillvalue,
     get_variable_metadata,
+    save_datasets,
 )
 from roms_tools.setup.mixins import ROMSToolsMixins
 from roms_tools.setup.plot import _plot, _section_plot, _profile_plot, _line_plot
-from roms_tools.utils import partition
 import matplotlib.pyplot as plt
 
 
@@ -489,7 +489,7 @@ class InitialConditions(ROMSToolsMixins):
         This method supports saving the dataset in two modes:
 
         1. **Single File Mode (default)**:
-           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath`.
+           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
 
         2. **Partitioned Mode**:
            - If either `nx` or `ny` is provided, the dataset is divided into `nx` by `ny` spatial tiles and each tile is saved as a separate file.
@@ -507,30 +507,16 @@ class InitialConditions(ROMSToolsMixins):
         Returns
         -------
         None
+            This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        if nx is None and ny is None:
-            print("Saving the following file:")
-            print(filepath)
-            self.ds.to_netcdf(filepath)
-        else:
-            nx = nx or 1
-            ny = ny or 1
+        dataset_list = [self.ds]
+        output_filenames = [filepath]
 
-            file_numbers, partitioned_datasets = partition(self.ds, nx=nx, ny=ny)
-
-            paths_to_partitioned_files = [
-                f"{filepath}.{file_number}.nc" for file_number in file_numbers
-            ]
-
-            print("Saving the following files:")
-            for path in paths_to_partitioned_files:
-                print(path)
-
-            xr.save_mfdataset(partitioned_datasets, paths_to_partitioned_files)
+        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -509,6 +509,9 @@ class InitialConditions(ROMSToolsMixins):
         None
         """
 
+        if filepath.endswith(".nc"):
+            filepath = filepath[:-3]
+
         if nx is None and ny is None:
             print("Saving the following file:")
             print(filepath)

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -447,6 +447,9 @@ class SurfaceForcing(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
+        if filepath.endswith(".nc"):
+            filepath = filepath[:-3]
+
         dataset_list = []
         output_filenames = []
 

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -16,9 +16,9 @@ from roms_tools.setup.utils import (
     interpolate_from_rho_to_u,
     interpolate_from_rho_to_v,
     get_variable_metadata,
+    save_datasets,
 )
 from roms_tools.setup.mixins import ROMSToolsMixins
-from roms_tools.utils import partition
 import matplotlib.pyplot as plt
 
 
@@ -270,7 +270,7 @@ class TidalForcing(ROMSToolsMixins):
         This method supports saving the dataset in two modes:
 
         1. **Single File Mode (default)**:
-           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath`.
+           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
 
         2. **Partitioned Mode**:
            - If either `nx` or `ny` is provided, the dataset is divided into `nx` by `ny` spatial tiles and each tile is saved as a separate file.
@@ -288,30 +288,16 @@ class TidalForcing(ROMSToolsMixins):
         Returns
         -------
         None
+            This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        if nx is None and ny is None:
-            print("Saving the following file:")
-            print(filepath)
-            self.ds.to_netcdf(filepath)
-        else:
-            nx = nx or 1
-            ny = ny or 1
+        dataset_list = [self.ds]
+        output_filenames = [filepath]
 
-            file_numbers, partitioned_datasets = partition(self.ds, nx=nx, ny=ny)
-
-            paths_to_partitioned_files = [
-                f"{filepath}.{file_number}.nc" for file_number in file_numbers
-            ]
-
-            print("Saving the following files:")
-            for path in paths_to_partitioned_files:
-                print(path)
-
-            xr.save_mfdataset(partitioned_datasets, paths_to_partitioned_files)
+        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -290,6 +290,9 @@ class TidalForcing(ROMSToolsMixins):
         None
         """
 
+        if filepath.endswith(".nc"):
+            filepath = filepath[:-3]
+
         if nx is None and ny is None:
             print("Saving the following file:")
             print(filepath)

--- a/roms_tools/tests/test_setup/test_boundary_forcing.py
+++ b/roms_tools/tests/test_setup/test_boundary_forcing.py
@@ -102,24 +102,20 @@ def test_boundary_forcing_plot_save(
         filepath = tmpfile.name
 
     boundary_forcing.save(filepath)
-    extended_filepath = filepath + "_20210629-29.nc"
 
-    try:
-        assert os.path.exists(extended_filepath)
-    finally:
-        os.remove(extended_filepath)
+    if filepath.endswith(".nc"):
+        filepath = filepath[:-3]
+    extended_filepath = filepath + "_202106.nc"
+
+    assert os.path.exists(extended_filepath)
+    os.remove(extended_filepath)
 
     boundary_forcing.save(filepath, nx=2)
-    expected_filepath_list = [
-        f"{filepath}_20210629-29.{index}.nc" for index in range(2)
-    ]
+    expected_filepath_list = [f"{filepath}_202106.{index}.nc" for index in range(2)]
 
-    try:
-        for expected_filepath in expected_filepath_list:
-            assert os.path.exists(expected_filepath)
-    finally:
-        for expected_filepath in expected_filepath_list:
-            os.remove(expected_filepath)
+    for expected_filepath in expected_filepath_list:
+        assert os.path.exists(expected_filepath)
+        os.remove(expected_filepath)
 
 
 def test_bgc_boundary_forcing_plot_save(
@@ -139,22 +135,20 @@ def test_bgc_boundary_forcing_plot_save(
         filepath = tmpfile.name
 
     bgc_boundary_forcing_from_climatology.save(filepath)
+
+    if filepath.endswith(".nc"):
+        filepath = filepath[:-3]
     extended_filepath = filepath + "_clim.nc"
 
-    try:
-        assert os.path.exists(extended_filepath)
-    finally:
-        os.remove(extended_filepath)
+    assert os.path.exists(extended_filepath)
+    os.remove(extended_filepath)
 
     bgc_boundary_forcing_from_climatology.save(filepath, ny=2)
     expected_filepath_list = [f"{filepath}_clim.{index}.nc" for index in range(2)]
 
-    try:
-        for expected_filepath in expected_filepath_list:
-            assert os.path.exists(expected_filepath)
-    finally:
-        for expected_filepath in expected_filepath_list:
-            os.remove(expected_filepath)
+    for expected_filepath in expected_filepath_list:
+        assert os.path.exists(expected_filepath)
+        os.remove(expected_filepath)
 
 
 @pytest.mark.parametrize(

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -202,11 +202,15 @@ def test_initial_conditions_plot_save(initial_conditions_with_bgc_from_climatolo
     # Create a temporary file
     with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
         filepath = tmpfile.name
+
     initial_conditions_with_bgc_from_climatology.save(filepath)
+
+    if filepath.endswith(".nc"):
+        filepath = filepath[:-3]
     try:
-        assert os.path.exists(filepath)
+        assert os.path.exists(f"{filepath}.nc")
     finally:
-        os.remove(filepath)
+        os.remove(f"{filepath}.nc")
 
     initial_conditions_with_bgc_from_climatology.save(filepath, nx=2)
     expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(2)]

--- a/roms_tools/tests/test_setup/test_surface_forcing.py
+++ b/roms_tools/tests/test_setup/test_surface_forcing.py
@@ -494,24 +494,20 @@ def test_surface_forcing_plot_save(sfc_forcing_fixture, request, tmp_path):
         filepath = tmpfile.name
 
     sfc_forcing.save(filepath)
-    extended_filepath = filepath + "_20200201-01.nc"
 
-    try:
-        assert os.path.exists(extended_filepath)
-    finally:
-        os.remove(extended_filepath)
+    if filepath.endswith(".nc"):
+        filepath = filepath[:-3]
+    extended_filepath = filepath + "_202002.nc"
+
+    assert os.path.exists(extended_filepath)
+    os.remove(extended_filepath)
 
     sfc_forcing.save(filepath, nx=1)
-    expected_filepath_list = [
-        f"{filepath}_20200201-01.{index}.nc" for index in range(1)
-    ]
+    expected_filepath_list = [f"{filepath}_202002.{index}.nc" for index in range(1)]
 
-    try:
-        for expected_filepath in expected_filepath_list:
-            assert os.path.exists(expected_filepath)
-    finally:
-        for expected_filepath in expected_filepath_list:
-            os.remove(expected_filepath)
+    for expected_filepath in expected_filepath_list:
+        assert os.path.exists(expected_filepath)
+        os.remove(expected_filepath)
 
 
 def test_surface_forcing_bgc_plot_save(
@@ -529,24 +525,20 @@ def test_surface_forcing_bgc_plot_save(
         filepath = tmpfile.name
 
     bgc_surface_forcing.save(filepath)
-    extended_filepath = filepath + "_20200201-01.nc"
 
-    try:
-        assert os.path.exists(extended_filepath)
-    finally:
-        os.remove(extended_filepath)
+    if filepath.endswith(".nc"):
+        filepath = filepath[:-3]
+    extended_filepath = filepath + "_202002.nc"
+
+    assert os.path.exists(extended_filepath)
+    os.remove(extended_filepath)
 
     bgc_surface_forcing.save(filepath, ny=5)
-    expected_filepath_list = [
-        f"{filepath}_20200201-01.{index}.nc" for index in range(5)
-    ]
+    expected_filepath_list = [f"{filepath}_202002.{index}.nc" for index in range(5)]
 
-    try:
-        for expected_filepath in expected_filepath_list:
-            assert os.path.exists(expected_filepath)
-    finally:
-        for expected_filepath in expected_filepath_list:
-            os.remove(expected_filepath)
+    for expected_filepath in expected_filepath_list:
+        assert os.path.exists(expected_filepath)
+        os.remove(expected_filepath)
 
 
 def test_surface_forcing_bgc_from_clim_plot_save(
@@ -562,25 +554,22 @@ def test_surface_forcing_bgc_from_clim_plot_save(
     # Create a temporary file
     with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
         filepath = tmpfile.name
-        print(filepath)
 
     bgc_surface_forcing_from_climatology.save(filepath)
+
+    if filepath.endswith(".nc"):
+        filepath = filepath[:-3]
     extended_filepath = filepath + "_clim.nc"
 
-    try:
-        assert os.path.exists(extended_filepath)
-    finally:
-        os.remove(extended_filepath)
+    assert os.path.exists(extended_filepath)
+    os.remove(extended_filepath)
 
     bgc_surface_forcing_from_climatology.save(filepath, nx=5)
     expected_filepath_list = [f"{filepath}_clim.{index}.nc" for index in range(5)]
 
-    try:
-        for expected_filepath in expected_filepath_list:
-            assert os.path.exists(expected_filepath)
-    finally:
-        for expected_filepath in expected_filepath_list:
-            os.remove(expected_filepath)
+    for expected_filepath in expected_filepath_list:
+        assert os.path.exists(expected_filepath)
+        os.remove(expected_filepath)
 
 
 @pytest.mark.parametrize(

--- a/roms_tools/tests/test_setup/test_tides.py
+++ b/roms_tools/tests/test_setup/test_tides.py
@@ -174,25 +174,23 @@ def test_tidal_forcing_plot_save(tidal_forcing, tmp_path):
     tidal_forcing.plot(varname="ssh_Re", ntides=0)
 
     # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
+    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
         filepath = tmpfile.name
 
     tidal_forcing.save(filepath)
 
-    try:
-        assert os.path.exists(filepath)
-    finally:
-        os.remove(filepath)
+    if filepath.endswith(".nc"):
+        filepath = filepath[:-3]
+
+    assert os.path.exists(f"{filepath}.nc")
+    os.remove(f"{filepath}.nc")
 
     tidal_forcing.save(filepath, nx=3, ny=3)
     expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(9)]
 
-    try:
-        for expected_filepath in expected_filepath_list:
-            assert os.path.exists(expected_filepath)
-    finally:
-        for expected_filepath in expected_filepath_list:
-            os.remove(expected_filepath)
+    for expected_filepath in expected_filepath_list:
+        assert os.path.exists(expected_filepath)
+        os.remove(expected_filepath)
 
 
 def test_roundtrip_yaml(tidal_forcing):


### PR DESCRIPTION
This PR improves the naming convention for the files that are written by ROMS-Tools.

1. It makes sure that things like `xxx.nc.0.nc` don't happen, i.e., there is exactly one `.nc` at the end of each filename.
2. It improves the grouping and naming for the surface and boundary forcing fields as discussed with @dafyddstephenson:
  - for daily or higher frequency, the dataset is grouped by month with file format `_YYYYMM.nc`
  - for lower temporal frequency than daily, the dataset is grouped by year with file format `_YYYY.nc`

The code is also made more compact by moving shared / often used grouping and writing routines to the `utils.py` module.