### PR TITLE
Trigger computation before partitioning

### DIFF
--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -500,7 +500,7 @@ class BoundaryForcing(ROMSToolsMixins):
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        dataset_list, output_filenames = group_dataset(self.ds, filepath)
+        dataset_list, output_filenames = group_dataset(self.ds.load(), filepath)
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -546,7 +546,7 @@ class Grid:
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        dataset_list = [self.ds]
+        dataset_list = [self.ds.load()]
         output_filenames = [filepath]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -513,7 +513,7 @@ class InitialConditions(ROMSToolsMixins):
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        dataset_list = [self.ds]
+        dataset_list = [self.ds.load()]
         output_filenames = [filepath]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -446,7 +446,7 @@ class SurfaceForcing(ROMSToolsMixins):
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        dataset_list, output_filenames = group_dataset(self.ds, filepath)
+        dataset_list, output_filenames = group_dataset(self.ds.load(), filepath)
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -294,7 +294,7 @@ class TidalForcing(ROMSToolsMixins):
         if filepath.endswith(".nc"):
             filepath = filepath[:-3]
 
-        dataset_list = [self.ds]
+        dataset_list = [self.ds.load()]
         output_filenames = [filepath]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)


### PR DESCRIPTION
This PR changes the order of operations from
```
(partition(self.ds)).compute()
```
to 
```
partition(self.ds.compute())
```
This change results in a significant speed-up. Previously, the old method took x times longer for x partitions, meaning the time increased linearly with the number of partitions. With the new method, the execution time remains the same whether there is 1 partition or x partitions.

Closes #110.
