### PR TITLE
Compatibility with `pathlib`

### DIFF
--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -19,6 +19,7 @@ from roms_tools.setup.utils import (
 )
 from roms_tools.setup.plot import _section_plot, _line_plot
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -460,7 +461,7 @@ class BoundaryForcing(ROMSToolsMixins):
         else:
             _line_plot(field, title=title)
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the boundary forcing fields to netCDF4 files.
 
@@ -479,7 +480,7 @@ class BoundaryForcing(ROMSToolsMixins):
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path and filename for the output files. The format of the filenames depends on whether partitioning is used
             and the temporal range of the data. For partitioned datasets, files will be named with an additional index, e.g.,
             `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc.
@@ -494,10 +495,14 @@ class BoundaryForcing(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
 
-        dataset_list, output_filenames = group_dataset(self.ds.load(), filepath)
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
+
+        dataset_list, output_filenames = group_dataset(self.ds.load(), str(filepath))
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:

--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -505,15 +505,17 @@ class BoundaryForcing(ROMSToolsMixins):
         dataset_list, output_filenames = group_dataset(self.ds.load(), str(filepath))
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
-    def to_yaml(self, filepath: str) -> None:
+    def to_yaml(self, filepath: Union[str, Path]) -> None:
         """
         Export the parameters of the class to a YAML file, including the version of roms-tools.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file where the parameters will be saved.
         """
+        filepath = Path(filepath)
+
         # Serialize Grid data
         grid_data = asdict(self.grid)
         grid_data.pop("ds", None)  # Exclude non-serializable fields
@@ -546,20 +548,20 @@ class BoundaryForcing(ROMSToolsMixins):
             **boundary_forcing_data,
         }
 
-        with open(filepath, "w") as file:
+        with filepath.open("w") as file:
             # Write header
             file.write(header)
             # Write YAML data
             yaml.dump(yaml_data, file, default_flow_style=False)
 
     @classmethod
-    def from_yaml(cls, filepath: str) -> "BoundaryForcing":
+    def from_yaml(cls, filepath: Union[str, Path]) -> "BoundaryForcing":
         """
         Create an instance of the BoundaryForcing class from a YAML file.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file from which the parameters will be read.
 
         Returns
@@ -567,8 +569,9 @@ class BoundaryForcing(ROMSToolsMixins):
         BoundaryForcing
             An instance of the BoundaryForcing class.
         """
+        filepath = Path(filepath)
         # Read the entire file content
-        with open(filepath, "r") as file:
+        with filepath.open("r") as file:
             file_content = file.read()
 
         # Split the content into YAML documents

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -565,13 +565,13 @@ class Grid:
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     @classmethod
-    def from_file(cls, filepath: str) -> "Grid":
+    def from_file(cls, filepath: Union[str, Path]) -> "Grid":
         """
         Create a Grid instance from an existing file.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             Path to the file containing the grid information.
 
         Returns
@@ -680,15 +680,18 @@ class Grid:
 
         return grid
 
-    def to_yaml(self, filepath: str) -> None:
+    def to_yaml(self, filepath: Union[str, Path]) -> None:
         """
         Export the parameters of the class to a YAML file, including the version of roms-tools.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file where the parameters will be saved.
         """
+
+        filepath = Path(filepath)
+
         data = asdict(self)
         data.pop("ds", None)
         data.pop("straddle", None)
@@ -705,20 +708,20 @@ class Grid:
         # Use the class name as the top-level key
         yaml_data = {self.__class__.__name__: data}
 
-        with open(filepath, "w") as file:
+        with filepath.open("w") as file:
             # Write header
             file.write(header)
             # Write YAML data
             yaml.dump(yaml_data, file, default_flow_style=False)
 
     @classmethod
-    def from_yaml(cls, filepath: str) -> "Grid":
+    def from_yaml(cls, filepath: Union[str, Path]) -> "Grid":
         """
         Create an instance of the class from a YAML file.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file from which the parameters will be read.
 
         Returns
@@ -726,8 +729,10 @@ class Grid:
         Grid
             An instance of the Grid class.
         """
+
+        filepath = Path(filepath)
         # Read the entire file content
-        with open(filepath, "r") as file:
+        with filepath.open("r") as file:
             file_content = file.read()
 
         # Split the content into YAML documents

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -7,12 +7,14 @@ import matplotlib.pyplot as plt
 import yaml
 import importlib.metadata
 
+from typing import Union
 from roms_tools.setup.topography import _add_topography_and_mask, _add_velocity_masks
 from roms_tools.setup.plot import _plot, _section_plot, _profile_plot, _line_plot
 from roms_tools.setup.utils import interpolate_from_rho_to_u, interpolate_from_rho_to_v
 from roms_tools.setup.vertical_coordinate import sigma_stretch, compute_depth
 from roms_tools.setup.utils import extract_single_value, save_datasets
 import warnings
+from pathlib import Path
 
 RADIUS_OF_EARTH = 6371315.0  # in m
 
@@ -522,7 +524,7 @@ class Grid:
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the grid information to a netCDF4 file.
 
@@ -537,7 +539,7 @@ class Grid:
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path or filename where the dataset should be saved.
         nx : int, optional
             The number of partitions along the x-axis. If `None`, no partitioning is done.
@@ -550,11 +552,15 @@ class Grid:
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
+
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
 
         dataset_list = [self.ds.load()]
-        output_filenames = [filepath]
+        output_filenames = [str(filepath)]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -16,6 +16,7 @@ from roms_tools.setup.utils import (
 from roms_tools.setup.mixins import ROMSToolsMixins
 from roms_tools.setup.plot import _plot, _section_plot, _profile_plot, _line_plot
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -482,7 +483,7 @@ class InitialConditions(ROMSToolsMixins):
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the initial conditions information to a netCDF4 file.
 
@@ -497,7 +498,7 @@ class InitialConditions(ROMSToolsMixins):
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path or filename where the dataset should be saved.
         nx : int, optional
             The number of partitions along the x-axis. If `None`, no partitioning is done.
@@ -510,11 +511,15 @@ class InitialConditions(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
+
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
 
         dataset_list = [self.ds.load()]
-        output_filenames = [filepath]
+        output_filenames = [str(filepath)]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -523,15 +523,17 @@ class InitialConditions(ROMSToolsMixins):
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
-    def to_yaml(self, filepath: str) -> None:
+    def to_yaml(self, filepath: Union[str, Path]) -> None:
         """
         Export the parameters of the class to a YAML file, including the version of roms-tools.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file where the parameters will be saved.
         """
+        filepath = Path(filepath)
+
         # Serialize Grid data
         grid_data = asdict(self.grid)
         grid_data.pop("ds", None)  # Exclude non-serializable fields
@@ -564,20 +566,20 @@ class InitialConditions(ROMSToolsMixins):
             **initial_conditions_data,
         }
 
-        with open(filepath, "w") as file:
+        with filepath.open("w") as file:
             # Write header
             file.write(header)
             # Write YAML data
             yaml.dump(yaml_data, file, default_flow_style=False)
 
     @classmethod
-    def from_yaml(cls, filepath: str) -> "InitialConditions":
+    def from_yaml(cls, filepath: Union[str, Path]) -> "InitialConditions":
         """
         Create an instance of the InitialConditions class from a YAML file.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file from which the parameters will be read.
 
         Returns
@@ -585,8 +587,9 @@ class InitialConditions(ROMSToolsMixins):
         InitialConditions
             An instance of the InitialConditions class.
         """
+        filepath = Path(filepath)
         # Read the entire file content
-        with open(filepath, "r") as file:
+        with filepath.open("r") as file:
             file_content = file.read()
 
         # Split the content into YAML documents

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -23,6 +23,7 @@ from roms_tools.setup.utils import (
 )
 from roms_tools.setup.plot import _plot
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -409,7 +410,7 @@ class SurfaceForcing(ROMSToolsMixins):
             c="g",
         )
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the surface forcing fields to netCDF4 files.
 
@@ -428,7 +429,7 @@ class SurfaceForcing(ROMSToolsMixins):
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path and filename for the output files. The format of the filenames depends on whether partitioning is used
             and the temporal range of the data. For partitioned datasets, files will be named with an additional index, e.g.,
             `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc.
@@ -443,10 +444,14 @@ class SurfaceForcing(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
 
-        dataset_list, output_filenames = group_dataset(self.ds.load(), filepath)
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
+
+        dataset_list, output_filenames = group_dataset(self.ds.load(), str(filepath))
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -454,15 +454,17 @@ class SurfaceForcing(ROMSToolsMixins):
         dataset_list, output_filenames = group_dataset(self.ds.load(), str(filepath))
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
-    def to_yaml(self, filepath: str) -> None:
+    def to_yaml(self, filepath: Union[str, Path]) -> None:
         """
         Export the parameters of the class to a YAML file, including the version of roms-tools.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file where the parameters will be saved.
         """
+        filepath = Path(filepath)
+
         # Serialize Grid data
         grid_data = asdict(self.grid)
         grid_data.pop("ds", None)  # Exclude non-serializable fields
@@ -499,20 +501,20 @@ class SurfaceForcing(ROMSToolsMixins):
             **surface_forcing_data,
         }
 
-        with open(filepath, "w") as file:
+        with filepath.open("w") as file:
             # Write header
             file.write(header)
             # Write YAML data
             yaml.dump(yaml_data, file, default_flow_style=False)
 
     @classmethod
-    def from_yaml(cls, filepath: str) -> "SurfaceForcing":
+    def from_yaml(cls, filepath: Union[str, Path]) -> "SurfaceForcing":
         """
         Create an instance of the SurfaceForcing class from a YAML file.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file from which the parameters will be read.
 
         Returns
@@ -520,8 +522,9 @@ class SurfaceForcing(ROMSToolsMixins):
         SurfaceForcing
             An instance of the SurfaceForcing class.
         """
+        filepath = Path(filepath)
         # Read the entire file content
-        with open(filepath, "r") as file:
+        with filepath.open("r") as file:
             file_content = file.read()
 
         # Split the content into YAML documents

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -20,6 +20,7 @@ from roms_tools.setup.utils import (
 )
 from roms_tools.setup.mixins import ROMSToolsMixins
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -291,11 +292,15 @@ class TidalForcing(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
+
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
 
         dataset_list = [self.ds.load()]
-        output_filenames = [filepath]
+        output_filenames = [str(filepath)]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -264,7 +264,7 @@ class TidalForcing(ROMSToolsMixins):
             title=title,
         )
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the tidal forcing information to a netCDF4 file.
 
@@ -279,7 +279,7 @@ class TidalForcing(ROMSToolsMixins):
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path or filename where the dataset should be saved.
         nx : int, optional
             The number of partitions along the x-axis. If `None`, no partitioning is done.
@@ -304,15 +304,17 @@ class TidalForcing(ROMSToolsMixins):
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
-    def to_yaml(self, filepath: str) -> None:
+    def to_yaml(self, filepath: Union[str, Path]) -> None:
         """
         Export the parameters of the class to a YAML file, including the version of roms-tools.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file where the parameters will be saved.
         """
+        filepath = Path(filepath)
+
         grid_data = asdict(self.grid)
         grid_data.pop("ds", None)  # Exclude non-serializable fields
         grid_data.pop("straddle", None)
@@ -342,20 +344,20 @@ class TidalForcing(ROMSToolsMixins):
         # Combine both sections
         yaml_data = {**grid_yaml_data, **tidal_forcing_data}
 
-        with open(filepath, "w") as file:
+        with filepath.open("w") as file:
             # Write header
             file.write(header)
             # Write YAML data
             yaml.dump(yaml_data, file, default_flow_style=False)
 
     @classmethod
-    def from_yaml(cls, filepath: str) -> "TidalForcing":
+    def from_yaml(cls, filepath: Union[str, Path]) -> "TidalForcing":
         """
         Create an instance of the TidalForcing class from a YAML file.
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The path to the YAML file from which the parameters will be read.
 
         Returns
@@ -363,8 +365,9 @@ class TidalForcing(ROMSToolsMixins):
         TidalForcing
             An instance of the TidalForcing class.
         """
+        filepath = Path(filepath)
         # Read the entire file content
-        with open(filepath, "r") as file:
+        with filepath.open("r") as file:
             file_content = file.read()
 
         # Split the content into YAML documents

--- a/roms_tools/tests/test_setup/test_boundary_forcing.py
+++ b/roms_tools/tests/test_setup/test_boundary_forcing.py
@@ -1,10 +1,9 @@
 import pytest
 from datetime import datetime
 from roms_tools import BoundaryForcing
-import tempfile
-import os
 import textwrap
 from roms_tools.setup.download import download_test_data
+from pathlib import Path
 
 
 def test_boundary_forcing_creation(boundary_forcing):
@@ -79,9 +78,7 @@ def test_boundary_forcing_creation_with_bgc(bgc_boundary_forcing_from_climatolog
     assert hasattr(bgc_boundary_forcing_from_climatology.ds, "climatology")
 
 
-def test_boundary_forcing_plot_save(
-    boundary_forcing,
-):
+def test_boundary_forcing_plot_save(boundary_forcing, tmp_path):
     """
     Test plot and save methods.
     """
@@ -97,29 +94,33 @@ def test_boundary_forcing_plot_save(
     boundary_forcing.plot(varname="vbar_north")
     boundary_forcing.plot(varname="ubar_west")
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
-        filepath = tmpfile.name
+    for file_str in ["test_bf", "test_bf.nc"]:
+        # Create a temporary filepath using the tmp_path fixture
+        for filepath in [
+            tmp_path / file_str,
+            str(tmp_path / file_str),
+        ]:  # test for Path object and str
 
-    boundary_forcing.save(filepath)
+            # Test saving without partitioning
+            boundary_forcing.save(filepath)
+            # Test saving with partitioning
+            boundary_forcing.save(filepath, nx=2)
 
-    if filepath.endswith(".nc"):
-        filepath = filepath[:-3]
-    extended_filepath = filepath + "_202106.nc"
+            filepath_str = str(Path(filepath).with_suffix(""))
+            expected_filepath = Path(f"{filepath_str}_202106.nc")
+            assert expected_filepath.exists()
+            expected_filepath.unlink()
 
-    assert os.path.exists(extended_filepath)
-    os.remove(extended_filepath)
-
-    boundary_forcing.save(filepath, nx=2)
-    expected_filepath_list = [f"{filepath}_202106.{index}.nc" for index in range(2)]
-
-    for expected_filepath in expected_filepath_list:
-        assert os.path.exists(expected_filepath)
-        os.remove(expected_filepath)
+            expected_filepath_list = [
+                (filepath_str + f"_202106.{index}.nc") for index in range(2)
+            ]
+            for expected_filepath in expected_filepath_list:
+                assert Path(expected_filepath).exists()
+                Path(expected_filepath).unlink()
 
 
 def test_bgc_boundary_forcing_plot_save(
-    bgc_boundary_forcing_from_climatology,
+    bgc_boundary_forcing_from_climatology, tmp_path
 ):
     """
     Test plot and save methods.
@@ -130,25 +131,29 @@ def test_bgc_boundary_forcing_plot_save(
     bgc_boundary_forcing_from_climatology.plot(varname="ALK_north")
     bgc_boundary_forcing_from_climatology.plot(varname="ALK_west")
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
-        filepath = tmpfile.name
+    for file_str in ["test_bf", "test_bf.nc"]:
+        # Create a temporary filepath using the tmp_path fixture
+        for filepath in [
+            tmp_path / file_str,
+            str(tmp_path / file_str),
+        ]:  # test for Path object and str
 
-    bgc_boundary_forcing_from_climatology.save(filepath)
+            # Test saving without partitioning
+            bgc_boundary_forcing_from_climatology.save(filepath)
+            # Test saving with partitioning
+            bgc_boundary_forcing_from_climatology.save(filepath, ny=2)
 
-    if filepath.endswith(".nc"):
-        filepath = filepath[:-3]
-    extended_filepath = filepath + "_clim.nc"
+            filepath_str = str(Path(filepath).with_suffix(""))
+            expected_filepath = Path(f"{filepath_str}_clim.nc")
+            assert expected_filepath.exists()
+            expected_filepath.unlink()
 
-    assert os.path.exists(extended_filepath)
-    os.remove(extended_filepath)
-
-    bgc_boundary_forcing_from_climatology.save(filepath, ny=2)
-    expected_filepath_list = [f"{filepath}_clim.{index}.nc" for index in range(2)]
-
-    for expected_filepath in expected_filepath_list:
-        assert os.path.exists(expected_filepath)
-        os.remove(expected_filepath)
+            expected_filepath_list = [
+                (filepath_str + f"_clim.{index}.nc") for index in range(2)
+            ]
+            for expected_filepath in expected_filepath_list:
+                assert Path(expected_filepath).exists()
+                Path(expected_filepath).unlink()
 
 
 @pytest.mark.parametrize(
@@ -158,27 +163,28 @@ def test_bgc_boundary_forcing_plot_save(
         "bgc_boundary_forcing_from_climatology",
     ],
 )
-def test_roundtrip_yaml(bdry_forcing_fixture, request):
+def test_roundtrip_yaml(bdry_forcing_fixture, request, tmp_path):
     """Test that creating a BoundaryForcing object, saving its parameters to yaml file, and re-opening yaml file creates the same object."""
 
     bdry_forcing = request.getfixturevalue(bdry_forcing_fixture)
+    # Create a temporary filepath using the tmp_path fixture
+    file_str = "test_yaml"
+    for filepath in [
+        tmp_path / file_str,
+        str(tmp_path / file_str),
+    ]:  # test for Path object and str
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
-        filepath = tmpfile.name
-
-    try:
         bdry_forcing.to_yaml(filepath)
 
-        boundary_forcing_from_file = BoundaryForcing.from_yaml(filepath)
+        bdry_forcing_from_file = BoundaryForcing.from_yaml(filepath)
 
-        assert bdry_forcing == boundary_forcing_from_file
+        assert bdry_forcing == bdry_forcing_from_file
 
-    finally:
-        os.remove(filepath)
+        filepath = Path(filepath)
+        filepath.unlink()
 
 
-def test_from_yaml_missing_boundary_forcing():
+def test_from_yaml_missing_boundary_forcing(tmp_path):
     yaml_content = textwrap.dedent(
         """\
     ---
@@ -199,14 +205,24 @@ def test_from_yaml_missing_boundary_forcing():
     """
     )
 
-    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-        yaml_filepath = tmp_file.name
-        tmp_file.write(yaml_content.encode())
+    # Create a temporary filepath using the tmp_path fixture
+    file_str = "test_yaml"
+    for yaml_filepath in [
+        tmp_path / file_str,
+        str(tmp_path / file_str),
+    ]:  # test for Path object and str
 
-    try:
+        # Write YAML content to file
+        if isinstance(yaml_filepath, Path):
+            yaml_filepath.write_text(yaml_content)
+        else:
+            with open(yaml_filepath, "w") as f:
+                f.write(yaml_content)
+
         with pytest.raises(
             ValueError, match="No BoundaryForcing configuration found in the YAML file."
         ):
             BoundaryForcing.from_yaml(yaml_filepath)
-    finally:
-        os.remove(yaml_filepath)
+
+        yaml_filepath = Path(yaml_filepath)
+        yaml_filepath.unlink()

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -3,11 +3,10 @@ from datetime import datetime
 from roms_tools import InitialConditions, Grid
 import xarray as xr
 import numpy as np
-import tempfile
-import os
 import textwrap
 from roms_tools.setup.download import download_test_data
 from roms_tools.setup.datasets import CESMBGCDataset
+from pathlib import Path
 
 
 @pytest.mark.parametrize(
@@ -162,7 +161,9 @@ def test_interpolation_from_climatology(initial_conditions_with_bgc_from_climato
     )
 
 
-def test_initial_conditions_plot_save(initial_conditions_with_bgc_from_climatology):
+def test_initial_conditions_plot_save(
+    initial_conditions_with_bgc_from_climatology, tmp_path
+):
     """
     Test plot and save methods.
     """
@@ -199,49 +200,54 @@ def test_initial_conditions_plot_save(initial_conditions_with_bgc_from_climatolo
     initial_conditions_with_bgc_from_climatology.plot(varname="ALK", s=0, xi=0)
     initial_conditions_with_bgc_from_climatology.plot(varname="ALK", eta=0, xi=0)
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
-        filepath = tmpfile.name
+    for file_str in ["test_ic", "test_ic.nc"]:
+        # Create a temporary filepath using the tmp_path fixture
+        for filepath in [
+            tmp_path / file_str,
+            str(tmp_path / file_str),
+        ]:  # test for Path object and str
 
-    initial_conditions_with_bgc_from_climatology.save(filepath)
+            # Test saving without partitioning
+            initial_conditions_with_bgc_from_climatology.save(filepath)
+            # Test saving with partitioning
+            initial_conditions_with_bgc_from_climatology.save(filepath, nx=2)
 
-    if filepath.endswith(".nc"):
-        filepath = filepath[:-3]
-    try:
-        assert os.path.exists(f"{filepath}.nc")
-    finally:
-        os.remove(f"{filepath}.nc")
+            # Check if the .nc file was created
+            filepath = Path(filepath)
+            assert (filepath.with_suffix(".nc")).exists()
+            # Clean up the .nc file
+            (filepath.with_suffix(".nc")).unlink()
 
-    initial_conditions_with_bgc_from_climatology.save(filepath, nx=2)
-    expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(2)]
-
-    try:
-        for expected_filepath in expected_filepath_list:
-            assert os.path.exists(expected_filepath)
-    finally:
-        for expected_filepath in expected_filepath_list:
-            os.remove(expected_filepath)
+            filepath_str = str(filepath.with_suffix(""))
+            expected_filepath_list = [
+                (filepath_str + f".{index}.nc") for index in range(2)
+            ]
+            for expected_filepath in expected_filepath_list:
+                assert Path(expected_filepath).exists()
+                Path(expected_filepath).unlink()
 
 
-def test_roundtrip_yaml(initial_conditions):
+def test_roundtrip_yaml(initial_conditions, tmp_path):
     """Test that creating an InitialConditions object, saving its parameters to yaml file, and re-opening yaml file creates the same object."""
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
-        filepath = tmpfile.name
+    # Create a temporary filepath using the tmp_path fixture
+    file_str = "test_yaml"
+    for filepath in [
+        tmp_path / file_str,
+        str(tmp_path / file_str),
+    ]:  # test for Path object and str
 
-    try:
         initial_conditions.to_yaml(filepath)
 
         initial_conditions_from_file = InitialConditions.from_yaml(filepath)
 
         assert initial_conditions == initial_conditions_from_file
 
-    finally:
-        os.remove(filepath)
+        filepath = Path(filepath)
+        filepath.unlink()
 
 
-def test_from_yaml_missing_initial_conditions():
+def test_from_yaml_missing_initial_conditions(tmp_path):
     yaml_content = textwrap.dedent(
         """\
     ---
@@ -262,15 +268,25 @@ def test_from_yaml_missing_initial_conditions():
     """
     )
 
-    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-        yaml_filepath = tmp_file.name
-        tmp_file.write(yaml_content.encode())
+    # Create a temporary filepath using the tmp_path fixture
+    file_str = "test_yaml"
+    for yaml_filepath in [
+        tmp_path / file_str,
+        str(tmp_path / file_str),
+    ]:  # test for Path object and str
 
-    try:
+        # Write YAML content to file
+        if isinstance(yaml_filepath, Path):
+            yaml_filepath.write_text(yaml_content)
+        else:
+            with open(yaml_filepath, "w") as f:
+                f.write(yaml_content)
+
         with pytest.raises(
             ValueError,
             match="No InitialConditions configuration found in the YAML file.",
         ):
             InitialConditions.from_yaml(yaml_filepath)
-    finally:
-        os.remove(yaml_filepath)
+
+        yaml_filepath = Path(yaml_filepath)
+        yaml_filepath.unlink()

--- a/roms_tools/tests/test_setup/test_surface_forcing.py
+++ b/roms_tools/tests/test_setup/test_surface_forcing.py
@@ -2,9 +2,8 @@ import pytest
 from datetime import datetime
 from roms_tools import Grid, SurfaceForcing
 from roms_tools.setup.download import download_test_data
-import tempfile
-import os
 import textwrap
+from pathlib import Path
 
 
 @pytest.fixture
@@ -489,30 +488,32 @@ def test_surface_forcing_plot_save(sfc_forcing_fixture, request, tmp_path):
     sfc_forcing = request.getfixturevalue(sfc_forcing_fixture)
     sfc_forcing.plot(varname="uwnd", time=0)
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
-        filepath = tmpfile.name
+    for file_str in ["test_sf", "test_sf.nc"]:
+        # Create a temporary filepath using the tmp_path fixture
+        for filepath in [
+            tmp_path / file_str,
+            str(tmp_path / file_str),
+        ]:  # test for Path object and str
 
-    sfc_forcing.save(filepath)
+            # Test saving without partitioning
+            sfc_forcing.save(filepath)
+            # Test saving with partitioning
+            sfc_forcing.save(filepath, nx=1)
 
-    if filepath.endswith(".nc"):
-        filepath = filepath[:-3]
-    extended_filepath = filepath + "_202002.nc"
+            filepath_str = str(Path(filepath).with_suffix(""))
+            expected_filepath = Path(f"{filepath_str}_202002.nc")
+            assert expected_filepath.exists()
+            expected_filepath.unlink()
 
-    assert os.path.exists(extended_filepath)
-    os.remove(extended_filepath)
-
-    sfc_forcing.save(filepath, nx=1)
-    expected_filepath_list = [f"{filepath}_202002.{index}.nc" for index in range(1)]
-
-    for expected_filepath in expected_filepath_list:
-        assert os.path.exists(expected_filepath)
-        os.remove(expected_filepath)
+            expected_filepath_list = [
+                (filepath_str + f"_202002.{index}.nc") for index in range(1)
+            ]
+            for expected_filepath in expected_filepath_list:
+                assert Path(expected_filepath).exists()
+                Path(expected_filepath).unlink()
 
 
-def test_surface_forcing_bgc_plot_save(
-    bgc_surface_forcing,
-):
+def test_surface_forcing_bgc_plot_save(bgc_surface_forcing, tmp_path):
     """
     Test plot and save methods.
     """
@@ -520,29 +521,33 @@ def test_surface_forcing_bgc_plot_save(
     # Check the values in the dataset
     bgc_surface_forcing.plot(varname="pco2_air", time=0)
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
-        filepath = tmpfile.name
+    for file_str in ["test_sf", "test_sf.nc"]:
+        # Create a temporary filepath using the tmp_path fixture
+        for filepath in [
+            tmp_path / file_str,
+            str(tmp_path / file_str),
+        ]:  # test for Path object and str
 
-    bgc_surface_forcing.save(filepath)
+            # Test saving without partitioning
+            bgc_surface_forcing.save(filepath)
+            # Test saving with partitioning
+            bgc_surface_forcing.save(filepath, ny=5)
 
-    if filepath.endswith(".nc"):
-        filepath = filepath[:-3]
-    extended_filepath = filepath + "_202002.nc"
+            filepath_str = str(Path(filepath).with_suffix(""))
+            expected_filepath = Path(f"{filepath_str}_202002.nc")
+            assert expected_filepath.exists()
+            expected_filepath.unlink()
 
-    assert os.path.exists(extended_filepath)
-    os.remove(extended_filepath)
-
-    bgc_surface_forcing.save(filepath, ny=5)
-    expected_filepath_list = [f"{filepath}_202002.{index}.nc" for index in range(5)]
-
-    for expected_filepath in expected_filepath_list:
-        assert os.path.exists(expected_filepath)
-        os.remove(expected_filepath)
+            expected_filepath_list = [
+                (filepath_str + f"_202002.{index}.nc") for index in range(5)
+            ]
+            for expected_filepath in expected_filepath_list:
+                assert Path(expected_filepath).exists()
+                Path(expected_filepath).unlink()
 
 
 def test_surface_forcing_bgc_from_clim_plot_save(
-    bgc_surface_forcing_from_climatology,
+    bgc_surface_forcing_from_climatology, tmp_path
 ):
     """
     Test plot and save methods.
@@ -551,25 +556,29 @@ def test_surface_forcing_bgc_from_clim_plot_save(
     # Check the values in the dataset
     bgc_surface_forcing_from_climatology.plot(varname="pco2_air", time=0)
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=True) as tmpfile:
-        filepath = tmpfile.name
+    for file_str in ["test_sf", "test_sf.nc"]:
+        # Create a temporary filepath using the tmp_path fixture
+        for filepath in [
+            tmp_path / file_str,
+            str(tmp_path / file_str),
+        ]:  # test for Path object and str
 
-    bgc_surface_forcing_from_climatology.save(filepath)
+            # Test saving without partitioning
+            bgc_surface_forcing_from_climatology.save(filepath)
+            # Test saving with partitioning
+            bgc_surface_forcing_from_climatology.save(filepath, nx=5)
 
-    if filepath.endswith(".nc"):
-        filepath = filepath[:-3]
-    extended_filepath = filepath + "_clim.nc"
+            filepath_str = str(Path(filepath).with_suffix(""))
+            expected_filepath = Path(f"{filepath_str}_clim.nc")
+            assert expected_filepath.exists()
+            expected_filepath.unlink()
 
-    assert os.path.exists(extended_filepath)
-    os.remove(extended_filepath)
-
-    bgc_surface_forcing_from_climatology.save(filepath, nx=5)
-    expected_filepath_list = [f"{filepath}_clim.{index}.nc" for index in range(5)]
-
-    for expected_filepath in expected_filepath_list:
-        assert os.path.exists(expected_filepath)
-        os.remove(expected_filepath)
+            expected_filepath_list = [
+                (filepath_str + f"_clim.{index}.nc") for index in range(5)
+            ]
+            for expected_filepath in expected_filepath_list:
+                assert Path(expected_filepath).exists()
+                Path(expected_filepath).unlink()
 
 
 @pytest.mark.parametrize(
@@ -582,27 +591,29 @@ def test_surface_forcing_bgc_from_clim_plot_save(
         "bgc_surface_forcing_from_climatology",
     ],
 )
-def test_roundtrip_yaml(sfc_forcing_fixture, request):
+def test_roundtrip_yaml(sfc_forcing_fixture, request, tmp_path):
     """Test that creating an SurfaceForcing object, saving its parameters to yaml file, and re-opening yaml file creates the same object."""
 
     sfc_forcing = request.getfixturevalue(sfc_forcing_fixture)
 
-    # Create a temporary file
-    with tempfile.NamedTemporaryFile(delete=False) as tmpfile:
-        filepath = tmpfile.name
+    # Create a temporary filepath using the tmp_path fixture
+    file_str = "test_yaml"
+    for filepath in [
+        tmp_path / file_str,
+        str(tmp_path / file_str),
+    ]:  # test for Path object and str
 
-    try:
         sfc_forcing.to_yaml(filepath)
 
         sfc_forcing_from_file = SurfaceForcing.from_yaml(filepath)
 
         assert sfc_forcing == sfc_forcing_from_file
 
-    finally:
-        os.remove(filepath)
+        filepath = Path(filepath)
+        filepath.unlink()
 
 
-def test_from_yaml_missing_surface_forcing():
+def test_from_yaml_missing_surface_forcing(tmp_path):
     yaml_content = textwrap.dedent(
         """\
     ---
@@ -623,15 +634,24 @@ def test_from_yaml_missing_surface_forcing():
     """
     )
 
-    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
-        yaml_filepath = tmp_file.name
-        tmp_file.write(yaml_content.encode())
+    # Create a temporary filepath using the tmp_path fixture
+    file_str = "test_yaml"
+    for yaml_filepath in [
+        tmp_path / file_str,
+        str(tmp_path / file_str),
+    ]:  # test for Path object and str
 
-    try:
+        # Write YAML content to file
+        if isinstance(yaml_filepath, Path):
+            yaml_filepath.write_text(yaml_content)
+        else:
+            with open(yaml_filepath, "w") as f:
+                f.write(yaml_content)
+
         with pytest.raises(
             ValueError,
             match="No SurfaceForcing configuration found in the YAML file.",
         ):
             SurfaceForcing.from_yaml(yaml_filepath)
-    finally:
-        os.remove(yaml_filepath)
+        yaml_filepath = Path(yaml_filepath)
+        yaml_filepath.unlink()


### PR DESCRIPTION
This PR makes sure that ROMS-Tool's (netcdf and yaml) write and read routines are compatible with `filepath` being either a `str` or a `pathlib.Path`.

Changes:
* Updated the routines
* Updated the docstrings
* Added tests that check for `str` and `pathlib.Path` compatibility

Closes #117.