### PR TITLE
Correct ordering of tiles

### DIFF
--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -19,6 +19,7 @@ from roms_tools.setup.utils import (
 )
 from roms_tools.setup.plot import _section_plot, _line_plot
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -460,7 +461,7 @@ class BoundaryForcing(ROMSToolsMixins):
         else:
             _line_plot(field, title=title)
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the boundary forcing fields to netCDF4 files.
 
@@ -479,7 +480,7 @@ class BoundaryForcing(ROMSToolsMixins):
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path and filename for the output files. The format of the filenames depends on whether partitioning is used
             and the temporal range of the data. For partitioned datasets, files will be named with an additional index, e.g.,
             `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc.
@@ -494,10 +495,14 @@ class BoundaryForcing(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
 
-        dataset_list, output_filenames = group_dataset(self.ds.load(), filepath)
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
+
+        dataset_list, output_filenames = group_dataset(self.ds.load(), str(filepath))
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:

--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -461,7 +461,9 @@ class BoundaryForcing(ROMSToolsMixins):
         else:
             _line_plot(field, title=title)
 
-    def save(self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the boundary forcing fields to netCDF4 files.
 

--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -461,7 +461,9 @@ class BoundaryForcing(ROMSToolsMixins):
         else:
             _line_plot(field, title=title)
 
-    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the boundary forcing fields to netCDF4 files.
 
@@ -471,12 +473,12 @@ class BoundaryForcing(ROMSToolsMixins):
         There are two modes of saving the dataset:
 
         1. **Single File Mode (default)**:
-           - If both `nx` and `ny` are `None`, the entire dataset, divided by temporal subsets, is saved as a single netCDF4 file
+           - If both `np_eta` and `np_xi` are `None`, the entire dataset, divided by temporal subsets, is saved as a single netCDF4 file
              with the base filename specified by `filepath.nc`.
 
         2. **Partitioned Mode**:
-           - If either `nx` or `ny` is specified, the dataset is divided into spatial tiles along the x-axis and y-axis.
-             Each spatial tile is saved as a separate netCDF4 file.
+           - If either `np_eta` or `np_xi` is specified, the dataset is divided into spatial tiles along the eta-axis and xi-axis.
+           - Each spatial tile is saved as a separate netCDF4 file.
 
         Parameters
         ----------
@@ -484,10 +486,10 @@ class BoundaryForcing(ROMSToolsMixins):
             The base path and filename for the output files. The format of the filenames depends on whether partitioning is used
             and the temporal range of the data. For partitioned datasets, files will be named with an additional index, e.g.,
             `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc.
-        nx : int, optional
-            The number of partitions along the x-axis. If `None`, no spatial partitioning is performed.
-        ny : int, optional
-            The number of partitions along the y-axis. If `None`, no spatial partitioning is performed.
+        np_eta : int, optional
+            The number of partitions along the `eta` direction. If `None`, no spatial partitioning is performed.
+        np_xi : int, optional
+            The number of partitions along the `xi` direction. If `None`, no spatial partitioning is performed.
 
         Returns
         -------
@@ -503,7 +505,7 @@ class BoundaryForcing(ROMSToolsMixins):
             filepath = filepath.with_suffix("")
 
         dataset_list, output_filenames = group_dataset(self.ds.load(), str(filepath))
-        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
+        save_datasets(dataset_list, output_filenames, np_eta=np_eta, np_xi=np_xi)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -7,12 +7,14 @@ import matplotlib.pyplot as plt
 import yaml
 import importlib.metadata
 
+from typing import Union
 from roms_tools.setup.topography import _add_topography_and_mask, _add_velocity_masks
 from roms_tools.setup.plot import _plot, _section_plot, _profile_plot, _line_plot
 from roms_tools.setup.utils import interpolate_from_rho_to_u, interpolate_from_rho_to_v
 from roms_tools.setup.vertical_coordinate import sigma_stretch, compute_depth
 from roms_tools.setup.utils import extract_single_value, save_datasets
 import warnings
+from pathlib import Path
 
 RADIUS_OF_EARTH = 6371315.0  # in m
 
@@ -522,7 +524,7 @@ class Grid:
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the grid information to a netCDF4 file.
 
@@ -537,7 +539,7 @@ class Grid:
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path or filename where the dataset should be saved.
         nx : int, optional
             The number of partitions along the x-axis. If `None`, no partitioning is done.
@@ -550,11 +552,15 @@ class Grid:
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
+
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
 
         dataset_list = [self.ds.load()]
-        output_filenames = [filepath]
+        output_filenames = [str(filepath)]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -524,27 +524,29 @@ class Grid:
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the grid information to a netCDF4 file.
 
         This method supports saving the dataset in two modes:
 
         1. **Single File Mode (default)**:
-           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
+           - If both `np_eta` and `np_xi` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
 
         2. **Partitioned Mode**:
-           - If either `nx` or `ny` is provided, the dataset is divided into `nx` by `ny` spatial tiles and each tile is saved as a separate file.
+           - If either `np_eta` or `np_xi` is specified, the dataset is divided into spatial tiles along the eta-axis and xi-axis.
            - The files are saved as `filepath.0.nc`, `filepath.1.nc`, ..., where the numbering corresponds to the partition index.
 
         Parameters
         ----------
         filepath : Union[str, Path]
             The base path or filename where the dataset should be saved.
-        nx : int, optional
-            The number of partitions along the x-axis. If `None`, no partitioning is done.
-        ny : int, optional
-            The number of partitions along the y-axis. If `None`, no partitioning is done.
+        np_eta : int, optional
+            The number of partitions along the `eta` direction. If `None`, no spatial partitioning is performed.
+        np_xi : int, optional
+            The number of partitions along the `xi` direction. If `None`, no spatial partitioning is performed.
 
         Returns
         -------
@@ -562,7 +564,7 @@ class Grid:
         dataset_list = [self.ds.load()]
         output_filenames = [str(filepath)]
 
-        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
+        save_datasets(dataset_list, output_filenames, np_eta=np_eta, np_xi=np_xi)
 
     @classmethod
     def from_file(cls, filepath: str) -> "Grid":

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -524,7 +524,9 @@ class Grid:
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the grid information to a netCDF4 file.
 

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -16,6 +16,7 @@ from roms_tools.setup.utils import (
 from roms_tools.setup.mixins import ROMSToolsMixins
 from roms_tools.setup.plot import _plot, _section_plot, _profile_plot, _line_plot
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -482,7 +483,7 @@ class InitialConditions(ROMSToolsMixins):
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the initial conditions information to a netCDF4 file.
 
@@ -497,7 +498,7 @@ class InitialConditions(ROMSToolsMixins):
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path or filename where the dataset should be saved.
         nx : int, optional
             The number of partitions along the x-axis. If `None`, no partitioning is done.
@@ -510,11 +511,15 @@ class InitialConditions(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
+
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
 
         dataset_list = [self.ds.load()]
-        output_filenames = [filepath]
+        output_filenames = [str(filepath)]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -483,7 +483,9 @@ class InitialConditions(ROMSToolsMixins):
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the initial conditions information to a netCDF4 file.
 

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -483,27 +483,29 @@ class InitialConditions(ROMSToolsMixins):
                 else:
                     _line_plot(field, title=title)
 
-    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the initial conditions information to a netCDF4 file.
 
         This method supports saving the dataset in two modes:
 
         1. **Single File Mode (default)**:
-           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
+           - If both `np_eta` and `np_xi` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
 
         2. **Partitioned Mode**:
-           - If either `nx` or `ny` is provided, the dataset is divided into `nx` by `ny` spatial tiles and each tile is saved as a separate file.
+           - If either `np_eta` or `np_xi` is specified, the dataset is divided into spatial tiles along the eta-axis and xi-axis.
            - The files are saved as `filepath.0.nc`, `filepath.1.nc`, ..., where the numbering corresponds to the partition index.
 
         Parameters
         ----------
         filepath : Union[str, Path]
             The base path or filename where the dataset should be saved.
-        nx : int, optional
-            The number of partitions along the x-axis. If `None`, no partitioning is done.
-        ny : int, optional
-            The number of partitions along the y-axis. If `None`, no partitioning is done.
+        np_eta : int, optional
+            The number of partitions along the `eta` direction. If `None`, no spatial partitioning is performed.
+        np_xi : int, optional
+            The number of partitions along the `xi` direction. If `None`, no spatial partitioning is performed.
 
         Returns
         -------
@@ -521,7 +523,7 @@ class InitialConditions(ROMSToolsMixins):
         dataset_list = [self.ds.load()]
         output_filenames = [str(filepath)]
 
-        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
+        save_datasets(dataset_list, output_filenames, np_eta=np_eta, np_xi=np_xi)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -410,7 +410,9 @@ class SurfaceForcing(ROMSToolsMixins):
             c="g",
         )
 
-    def save(self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the surface forcing fields to netCDF4 files.
 

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -410,7 +410,9 @@ class SurfaceForcing(ROMSToolsMixins):
             c="g",
         )
 
-    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the surface forcing fields to netCDF4 files.
 
@@ -420,12 +422,12 @@ class SurfaceForcing(ROMSToolsMixins):
         There are two modes of saving the dataset:
 
         1. **Single File Mode (default)**:
-           - If both `nx` and `ny` are `None`, the entire dataset, divided by temporal subsets, is saved as a single netCDF4 file
+           - If both `np_eta` and `np_xi` are `None`, the entire dataset, divided by temporal subsets, is saved as a single netCDF4 file
              with the base filename specified by `filepath.nc`.
 
         2. **Partitioned Mode**:
-           - If either `nx` or `ny` is specified, the dataset is divided into spatial tiles along the x-axis and y-axis.
-             Each spatial tile is saved as a separate netCDF4 file.
+           - If either `np_eta` or `np_xi` is specified, the dataset is divided into spatial tiles along the eta-axis and xi-axis.
+           - Each spatial tile is saved as a separate netCDF4 file.
 
         Parameters
         ----------
@@ -433,10 +435,10 @@ class SurfaceForcing(ROMSToolsMixins):
             The base path and filename for the output files. The format of the filenames depends on whether partitioning is used
             and the temporal range of the data. For partitioned datasets, files will be named with an additional index, e.g.,
             `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc.
-        nx : int, optional
-            The number of partitions along the x-axis. If `None`, no spatial partitioning is performed.
-        ny : int, optional
-            The number of partitions along the y-axis. If `None`, no spatial partitioning is performed.
+        np_eta : int, optional
+            The number of partitions along the `eta` direction. If `None`, no spatial partitioning is performed.
+        np_xi : int, optional
+            The number of partitions along the `xi` direction. If `None`, no spatial partitioning is performed.
 
         Returns
         -------
@@ -452,7 +454,7 @@ class SurfaceForcing(ROMSToolsMixins):
             filepath = filepath.with_suffix("")
 
         dataset_list, output_filenames = group_dataset(self.ds.load(), str(filepath))
-        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
+        save_datasets(dataset_list, output_filenames, np_eta=np_eta, np_xi=np_xi)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -23,6 +23,7 @@ from roms_tools.setup.utils import (
 )
 from roms_tools.setup.plot import _plot
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -409,7 +410,7 @@ class SurfaceForcing(ROMSToolsMixins):
             c="g",
         )
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: Union[str, Path], nx: int = None, ny: int = None) -> None:
         """
         Save the surface forcing fields to netCDF4 files.
 
@@ -428,7 +429,7 @@ class SurfaceForcing(ROMSToolsMixins):
 
         Parameters
         ----------
-        filepath : str
+        filepath : Union[str, Path]
             The base path and filename for the output files. The format of the filenames depends on whether partitioning is used
             and the temporal range of the data. For partitioned datasets, files will be named with an additional index, e.g.,
             `"filepath_YYYYMM.0.nc"`, `"filepath_YYYYMM.1.nc"`, etc.
@@ -443,10 +444,14 @@ class SurfaceForcing(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
 
-        dataset_list, output_filenames = group_dataset(self.ds.load(), filepath)
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
+
+        dataset_list, output_filenames = group_dataset(self.ds.load(), str(filepath))
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 
     def to_yaml(self, filepath: str) -> None:

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -20,6 +20,7 @@ from roms_tools.setup.utils import (
 )
 from roms_tools.setup.mixins import ROMSToolsMixins
 import matplotlib.pyplot as plt
+from pathlib import Path
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -291,11 +292,15 @@ class TidalForcing(ROMSToolsMixins):
             This method does not return any value. It saves the dataset to netCDF4 files as specified.
         """
 
-        if filepath.endswith(".nc"):
-            filepath = filepath[:-3]
+        # Ensure filepath is a Path object
+        filepath = Path(filepath)
+
+        # Remove ".nc" suffix if present
+        if filepath.suffix == ".nc":
+            filepath = filepath.with_suffix("")
 
         dataset_list = [self.ds.load()]
-        output_filenames = [filepath]
+        output_filenames = [str(filepath)]
 
         save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
 

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -264,7 +264,9 @@ class TidalForcing(ROMSToolsMixins):
             title=title,
         )
 
-    def save(self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None) -> None:
+    def save(
+        self, filepath: Union[str, Path], np_eta: int = None, np_xi: int = None
+    ) -> None:
         """
         Save the tidal forcing information to a netCDF4 file.
 

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -264,27 +264,27 @@ class TidalForcing(ROMSToolsMixins):
             title=title,
         )
 
-    def save(self, filepath: str, nx: int = None, ny: int = None) -> None:
+    def save(self, filepath: str, np_eta: int = None, np_xi: int = None) -> None:
         """
         Save the tidal forcing information to a netCDF4 file.
 
         This method supports saving the dataset in two modes:
 
         1. **Single File Mode (default)**:
-           - If both `nx` and `ny` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
+           - If both `np_eta` and `np_xi` are `None`, the entire dataset is saved as a single file at the specified `filepath.nc`.
 
         2. **Partitioned Mode**:
-           - If either `nx` or `ny` is provided, the dataset is divided into `nx` by `ny` spatial tiles and each tile is saved as a separate file.
+           - If either `np_eta` or `np_xi` is specified, the dataset is divided into spatial tiles along the eta-axis and xi-axis.
            - The files are saved as `filepath.0.nc`, `filepath.1.nc`, ..., where the numbering corresponds to the partition index.
 
         Parameters
         ----------
         filepath : str
             The base path or filename where the dataset should be saved.
-        nx : int, optional
-            The number of partitions along the x-axis. If `None`, no partitioning is done.
-        ny : int, optional
-            The number of partitions along the y-axis. If `None`, no partitioning is done.
+        np_eta : int, optional
+            The number of partitions along the `eta` direction. If `None`, no spatial partitioning is performed.
+        np_xi : int, optional
+            The number of partitions along the `xi` direction. If `None`, no spatial partitioning is performed.
 
         Returns
         -------
@@ -302,7 +302,7 @@ class TidalForcing(ROMSToolsMixins):
         dataset_list = [self.ds.load()]
         output_filenames = [str(filepath)]
 
-        save_datasets(dataset_list, output_filenames, nx=nx, ny=ny)
+        save_datasets(dataset_list, output_filenames, np_eta=np_eta, np_xi=np_xi)
 
     def to_yaml(self, filepath: str) -> None:
         """

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -695,7 +695,7 @@ def group_by_year(ds, filepath):
     return dataset_list, output_filenames
 
 
-def save_datasets(dataset_list, output_filenames, nx=None, ny=None):
+def save_datasets(dataset_list, output_filenames, np_eta=None, np_xi=None):
     """
     Save the list of datasets to netCDF4 files, with optional spatial partitioning.
 
@@ -705,10 +705,10 @@ def save_datasets(dataset_list, output_filenames, nx=None, ny=None):
         List of datasets to be saved.
     output_filenames : list
         List of filenames for the output files.
-    nx : int, optional
-        Number of partitions along the x-axis. If None, no partitioning is applied.
-    ny : int, optional
-        Number of partitions along the y-axis. If None, no partitioning is applied.
+    np_eta : int, optional
+        The number of partitions along the `eta` direction. If `None`, no spatial partitioning is performed.
+    np_xi : int, optional
+        The number of partitions along the `xi` direction. If `None`, no spatial partitioning is performed.
 
     Returns
     -------
@@ -716,7 +716,7 @@ def save_datasets(dataset_list, output_filenames, nx=None, ny=None):
     """
 
     print("Saving the following files:")
-    if nx is None and ny is None:
+    if np_eta is None and np_xi is None:
         # Save the dataset as a single file
         output_filenames = [f"{filename}.nc" for filename in output_filenames]
         for filename in output_filenames:
@@ -724,13 +724,15 @@ def save_datasets(dataset_list, output_filenames, nx=None, ny=None):
         xr.save_mfdataset(dataset_list, output_filenames)
     else:
         # Partition the dataset and save each partition as a separate file
-        nx = nx or 1
-        ny = ny or 1
+        np_eta = np_eta or 1
+        np_xi = np_xi or 1
 
         partitioned_datasets = []
         partitioned_filenames = []
         for dataset, base_filename in zip(dataset_list, output_filenames):
-            partition_indices, partitions = partition(dataset, nx=nx, ny=ny)
+            partition_indices, partitions = partition(
+                dataset, np_eta=np_eta, np_xi=np_xi
+            )
             partition_filenames = [
                 f"{base_filename}.{index}.nc" for index in partition_indices
             ]

--- a/roms_tools/tests/test_setup/test_boundary_forcing.py
+++ b/roms_tools/tests/test_setup/test_boundary_forcing.py
@@ -110,7 +110,7 @@ def test_boundary_forcing_plot_save(
     assert os.path.exists(extended_filepath)
     os.remove(extended_filepath)
 
-    boundary_forcing.save(filepath, nx=2)
+    boundary_forcing.save(filepath, np_eta=2)
     expected_filepath_list = [f"{filepath}_202106.{index}.nc" for index in range(2)]
 
     for expected_filepath in expected_filepath_list:
@@ -143,7 +143,7 @@ def test_bgc_boundary_forcing_plot_save(
     assert os.path.exists(extended_filepath)
     os.remove(extended_filepath)
 
-    bgc_boundary_forcing_from_climatology.save(filepath, ny=2)
+    bgc_boundary_forcing_from_climatology.save(filepath, np_xi=2)
     expected_filepath_list = [f"{filepath}_clim.{index}.nc" for index in range(2)]
 
     for expected_filepath in expected_filepath_list:

--- a/roms_tools/tests/test_setup/test_grid.py
+++ b/roms_tools/tests/test_setup/test_grid.py
@@ -37,7 +37,7 @@ def test_plot_save_methods():
     assert os.path.exists(f"{filepath}.nc")
     os.remove(f"{filepath}.nc")
 
-    grid.save(filepath, nx=2, ny=5)
+    grid.save(filepath, np_eta=2, np_xi=5)
     expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(10)]
     for expected_filepath in expected_filepath_list:
         assert os.path.exists(expected_filepath)

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -212,7 +212,7 @@ def test_initial_conditions_plot_save(initial_conditions_with_bgc_from_climatolo
     finally:
         os.remove(f"{filepath}.nc")
 
-    initial_conditions_with_bgc_from_climatology.save(filepath, nx=2)
+    initial_conditions_with_bgc_from_climatology.save(filepath, np_eta=2)
     expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(2)]
 
     try:

--- a/roms_tools/tests/test_setup/test_surface_forcing.py
+++ b/roms_tools/tests/test_setup/test_surface_forcing.py
@@ -502,7 +502,7 @@ def test_surface_forcing_plot_save(sfc_forcing_fixture, request, tmp_path):
     assert os.path.exists(extended_filepath)
     os.remove(extended_filepath)
 
-    sfc_forcing.save(filepath, nx=1)
+    sfc_forcing.save(filepath, np_eta=1)
     expected_filepath_list = [f"{filepath}_202002.{index}.nc" for index in range(1)]
 
     for expected_filepath in expected_filepath_list:
@@ -533,7 +533,7 @@ def test_surface_forcing_bgc_plot_save(
     assert os.path.exists(extended_filepath)
     os.remove(extended_filepath)
 
-    bgc_surface_forcing.save(filepath, ny=5)
+    bgc_surface_forcing.save(filepath, np_xi=5)
     expected_filepath_list = [f"{filepath}_202002.{index}.nc" for index in range(5)]
 
     for expected_filepath in expected_filepath_list:
@@ -564,7 +564,7 @@ def test_surface_forcing_bgc_from_clim_plot_save(
     assert os.path.exists(extended_filepath)
     os.remove(extended_filepath)
 
-    bgc_surface_forcing_from_climatology.save(filepath, nx=5)
+    bgc_surface_forcing_from_climatology.save(filepath, np_eta=5)
     expected_filepath_list = [f"{filepath}_clim.{index}.nc" for index in range(5)]
 
     for expected_filepath in expected_filepath_list:

--- a/roms_tools/tests/test_setup/test_tides.py
+++ b/roms_tools/tests/test_setup/test_tides.py
@@ -185,7 +185,7 @@ def test_tidal_forcing_plot_save(tidal_forcing, tmp_path):
     assert os.path.exists(f"{filepath}.nc")
     os.remove(f"{filepath}.nc")
 
-    tidal_forcing.save(filepath, nx=3, ny=3)
+    tidal_forcing.save(filepath, np_eta=3, np_xi=3)
     expected_filepath_list = [f"{filepath}.{index}.nc" for index in range(9)]
 
     for expected_filepath in expected_filepath_list:

--- a/roms_tools/tests/test_utils.py
+++ b/roms_tools/tests/test_utils.py
@@ -16,7 +16,7 @@ def grid():
 
 class TestPartitionGrid:
     def test_partition_grid_along_x(self, grid):
-        _, [ds1, ds2, ds3] = partition(grid.ds, nx=3, ny=1)
+        _, [ds1, ds2, ds3] = partition(grid.ds, np_eta=3, np_xi=1)
 
         assert ds1.sizes == {
             "eta_rho": 11,
@@ -50,7 +50,7 @@ class TestPartitionGrid:
         }
 
     def test_partition_grid_along_y(self, grid):
-        _, [ds1, ds2, ds3] = partition(grid.ds, nx=1, ny=3)
+        _, [ds1, ds2, ds3] = partition(grid.ds, np_eta=1, np_xi=3)
 
         assert ds1.sizes == {
             "eta_rho": 32,
@@ -88,7 +88,7 @@ class TestPartitionGrid:
         # fmt: off
         _, [ds1, ds2, ds3,
          ds4, ds5, ds6,
-         ds7, ds8, ds9] = partition(grid.ds, nx=3, ny=3)
+         ds7, ds8, ds9] = partition(grid.ds, np_eta=3, np_xi=3)
         # fmt: on
 
         assert ds1.sizes == {
@@ -183,19 +183,23 @@ class TestPartitionGrid:
         }
 
     def test_partition_grid_no_op(self, grid):
-        _, partitioned_datasets = partition(grid.ds, nx=1, ny=1)
+        _, partitioned_datasets = partition(grid.ds, np_eta=1, np_xi=1)
 
         xrt.assert_identical(partitioned_datasets[0], grid.ds)
 
     def test_invalid_partitioning(self, grid):
-        with pytest.raises(ValueError, match="nx and ny must be positive integers"):
-            partition(grid.ds, nx=3.0, ny=1)
+        with pytest.raises(
+            ValueError, match="np_eta and np_xi must be positive integers"
+        ):
+            partition(grid.ds, np_eta=3.0, np_xi=1)
 
-        with pytest.raises(ValueError, match="nx and ny must be positive integers"):
-            partition(grid.ds, nx=-3, ny=1)
+        with pytest.raises(
+            ValueError, match="np_eta and np_xi must be positive integers"
+        ):
+            partition(grid.ds, np_eta=-3, np_xi=1)
 
         with pytest.raises(ValueError, match="cannot be evenly divided"):
-            partition(grid.ds, nx=4, ny=1)
+            partition(grid.ds, np_eta=4, np_xi=1)
 
 
 class TestPartitionMissingDims:
@@ -204,29 +208,29 @@ class TestPartitionMissingDims:
 
         ds_missing_dims = grid.ds.drop_dims(dims_to_drop)
 
-        _, partitioned_datasets = partition(ds_missing_dims, nx=1, ny=1)
+        _, partitioned_datasets = partition(ds_missing_dims, np_eta=1, np_xi=1)
 
         xrt.assert_identical(partitioned_datasets[0], ds_missing_dims)
 
     def test_partition_missing_all_dims(self, grid):
-        # this is all the partitionable dims, so in this case the file will just be copied nx * ny times
+        # this is all the partitionable dims, so in this case the file will just be copied np_eta * np_xi times
         dims_to_drop = ["eta_rho", "xi_rho", "xi_u", "eta_v", "eta_coarse", "xi_coarse"]
 
         ds_missing_dims = grid.ds.drop_dims(dims_to_drop)
 
-        _, partitioned_datasets = partition(ds_missing_dims, nx=1, ny=1)
+        _, partitioned_datasets = partition(ds_missing_dims, np_eta=1, np_xi=1)
 
         xrt.assert_identical(partitioned_datasets[0], ds_missing_dims)
 
 
 class TestFileNumbers:
     def test_partition_file_numbers(self, grid):
-        nx = 3
-        ny = 5
-        file_numbers, _ = partition(grid.ds, nx=nx, ny=ny)
+        np_eta = 3
+        np_xi = 5
+        file_numbers, _ = partition(grid.ds, np_eta=np_eta, np_xi=np_xi)
 
         # Generate the expected file numbers
-        expected_file_numbers = list(range(nx * ny))
+        expected_file_numbers = list(range(np_eta * np_xi))
 
         # Check if file_numbers is a continuous range without gaps
-        assert file_numbers == expected_file_numbers
+        assert set(file_numbers) == set(expected_file_numbers)

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -5,12 +5,12 @@ import xarray as xr
 
 
 def partition(
-    ds: xr.Dataset, nx: int = 1, ny: int = 1
+    ds: xr.Dataset, np_eta: int = 1, np_xi: int = 1
 ) -> tuple[list[int], list[xr.Dataset]]:
     """
     Partition a ROMS (Regional Ocean Modeling System) dataset into smaller spatial tiles.
 
-    This function divides the input dataset into `nx` by `ny` tiles, where each tile
+    This function divides the input dataset into `np_eta` by `np_xi` tiles, where each tile
     represents a subdomain of the original dataset. The partitioning is performed along
     the spatial dimensions `eta_rho`, `xi_rho`, `eta_v`, `xi_u`, `eta_coarse`, and `xi_coarse`,
     depending on which dimensions are present in the dataset.
@@ -20,11 +20,11 @@ def partition(
     ds : xr.Dataset
         The input ROMS dataset that is to be partitioned.
 
-    nx : int, optional
-        The number of partitions along the `eta` (latitude) direction. Must be a positive integer. Default is 1.
+    np_eta : int, optional
+        The number of partitions along the `eta` direction. Must be a positive integer. Default is 1.
 
-    ny : int, optional
-        The number of partitions along the `xi` (longitude) direction. Must be a positive integer. Default is 1.
+    np_xi : int, optional
+        The number of partitions along the `xi` direction. Must be a positive integer. Default is 1.
 
     Returns
     -------
@@ -36,13 +36,15 @@ def partition(
     Raises
     ------
     ValueError
-        If `nx` or `ny` is not a positive integer, or if the dataset cannot be evenly partitioned
+        If `np_eta` or `np_xi` is not a positive integer, or if the dataset cannot be evenly partitioned
         into the specified number of tiles.
 
 
     Example
     -------
-    >>> partitioned_file_numbers, partitioned_datasets = partition(ds, nx=2, ny=3)
+    >>> partitioned_file_numbers, partitioned_datasets = partition(
+    ...     ds, np_eta=2, np_xi=3
+    ... )
     >>> print(partitioned_file_numbers)
     [0, 1, 2, 3, 4, 5]
     >>> print([ds.sizes for ds in partitioned_datasets])
@@ -52,8 +54,13 @@ def partition(
     along the `xi` direction, resulting in a total of 6 partitions.
     """
 
-    if not isinstance(nx, Integral) or nx < 1 or not isinstance(ny, Integral) or ny < 1:
-        raise ValueError("nx and ny must be positive integers")
+    if (
+        not isinstance(np_eta, Integral)
+        or np_eta < 1
+        or not isinstance(np_xi, Integral)
+        or np_xi < 1
+    ):
+        raise ValueError("np_eta and np_xi must be positive integers")
 
     partitionable_dims_maybe_present = [
         "eta_rho",
@@ -112,29 +119,29 @@ def partition(
 
     if "eta_rho" in dims_to_partition:
         eta_rho_domain_size = integer_division_or_raise(
-            ds.sizes["eta_rho"] - 2 * n_eta_ghost_cells, nx, "eta_rho"
+            ds.sizes["eta_rho"] - 2 * n_eta_ghost_cells, np_eta, "eta_rho"
         )
     if "xi_rho" in dims_to_partition:
         xi_rho_domain_size = integer_division_or_raise(
-            ds.sizes["xi_rho"] - 2 * n_xi_ghost_cells, ny, "xi_rho"
+            ds.sizes["xi_rho"] - 2 * n_xi_ghost_cells, np_xi, "xi_rho"
         )
 
     if "eta_v" in dims_to_partition:
         eta_v_domain_size = integer_division_or_raise(
-            ds.sizes["eta_v"] - 1 * n_eta_ghost_cells, nx, "eta_v"
+            ds.sizes["eta_v"] - 1 * n_eta_ghost_cells, np_eta, "eta_v"
         )
     if "xi_u" in dims_to_partition:
         xi_u_domain_size = integer_division_or_raise(
-            ds.sizes["xi_u"] - 1 * n_xi_ghost_cells, ny, "xi_u"
+            ds.sizes["xi_u"] - 1 * n_xi_ghost_cells, np_xi, "xi_u"
         )
 
     if "eta_coarse" in dims_to_partition:
         eta_coarse_domain_size = integer_division_or_raise(
-            ds.sizes["eta_coarse"] - 2 * n_eta_ghost_cells, nx, "eta_coarse"
+            ds.sizes["eta_coarse"] - 2 * n_eta_ghost_cells, np_eta, "eta_coarse"
         )
     if "xi_coarse" in dims_to_partition:
         xi_coarse_domain_size = integer_division_or_raise(
-            ds.sizes["xi_coarse"] - 2 * n_xi_ghost_cells, ny, "xi_coarse"
+            ds.sizes["xi_coarse"] - 2 * n_xi_ghost_cells, np_xi, "xi_coarse"
         )
 
     # unpartitioned dimensions should have sizes unchanged
@@ -144,39 +151,39 @@ def partition(
 
     # TODO refactor to use two functions for odd- and even-length dimensions
     if "eta_v" in dims_to_partition:
-        partitioned_sizes["eta_v"] = [eta_v_domain_size] * (nx - 1) + [
+        partitioned_sizes["eta_v"] = [eta_v_domain_size] * (np_eta - 1) + [
             eta_v_domain_size + n_eta_ghost_cells
         ]
     if "xi_u" in dims_to_partition:
-        partitioned_sizes["xi_u"] = [xi_u_domain_size] * (ny - 1) + [
+        partitioned_sizes["xi_u"] = [xi_u_domain_size] * (np_xi - 1) + [
             xi_u_domain_size + n_xi_ghost_cells
         ]
 
-    if nx > 1:
+    if np_eta > 1:
         partitioned_sizes["eta_rho"] = (
             [eta_rho_domain_size + n_eta_ghost_cells]
-            + [eta_rho_domain_size] * (nx - 2)
+            + [eta_rho_domain_size] * (np_eta - 2)
             + [eta_rho_domain_size + n_eta_ghost_cells]
         )
 
         if "eta_coarse" in dims_to_partition:
             partitioned_sizes["eta_coarse"] = (
                 [eta_coarse_domain_size + n_eta_ghost_cells]
-                + [eta_coarse_domain_size] * (nx - 2)
+                + [eta_coarse_domain_size] * (np_eta - 2)
                 + [eta_coarse_domain_size + n_eta_ghost_cells]
             )
 
-    if ny > 1:
+    if np_xi > 1:
         partitioned_sizes["xi_rho"] = (
             [xi_rho_domain_size + n_xi_ghost_cells]
-            + [xi_rho_domain_size] * (ny - 2)
+            + [xi_rho_domain_size] * (np_xi - 2)
             + [xi_rho_domain_size + n_xi_ghost_cells]
         )
 
         if "xi_coarse" in dims_to_partition:
             partitioned_sizes["xi_coarse"] = (
                 [xi_coarse_domain_size + n_xi_ghost_cells]
-                + [xi_coarse_domain_size] * (ny - 2)
+                + [xi_coarse_domain_size] * (np_xi - 2)
                 + [xi_coarse_domain_size + n_xi_ghost_cells]
             )
 
@@ -189,9 +196,9 @@ def partition(
 
     file_numbers = []
     partitioned_datasets = []
-    for j in range(ny):
-        for i in range(nx):
-            file_number = j + (i * ny)
+    for j in range(np_xi):
+        for i in range(np_eta):
+            file_number = j + (i * np_xi)
             file_numbers.append(file_number)
 
             indexers = {}

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -191,7 +191,7 @@ def partition(
     partitioned_datasets = []
     for j in range(ny):
         for i in range(nx):
-            file_number = i + (j * nx)
+            file_number = j + (i * ny)
             file_numbers.append(file_number)
 
             indexers = {}


### PR DESCRIPTION
This PR
* corrects the ordering of the tiles (row-major --> column-major ordering)
* renames `nx` --> `np_eta`, `ny` --> `np_xi`

Closes #111 