### PR TITLE
Update documentation of partitioning

### DIFF
--- a/docs/partition.ipynb
+++ b/docs/partition.ipynb
@@ -84,7 +84,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Saving the following file:\n",
+      "Saving the following files:\n",
       "/glade/derecho/scratch/noraloose/examples/my_grid.nc\n"
      ]
     }
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file_numbers, partitioned_datasets = partition(ds, nx=2, ny=5)  # step 2"
+    "file_numbers, partitioned_datasets = partition(ds, np_eta=2, np_xi=5)  # step 2"
    ]
   },
   {
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "ab26dd1f-43ec-45f6-b7ac-eb3bc038ffa4",
    "metadata": {},
    "outputs": [],
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "aa90976d-29d3-480c-84df-2c91f8aa5bd4",
    "metadata": {},
    "outputs": [
@@ -208,7 +208,7 @@
        " '/glade/derecho/scratch/noraloose/examples/my_grid.9.nc']"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "4d103aa2-6fab-4e1a-97a8-1f1a3fbfd193",
    "metadata": {},
    "outputs": [],
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "77863475-d447-46cb-a619-89960c1d92a5",
    "metadata": {},
    "outputs": [
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "ca08a3a8-719f-4f64-942a-234d0064400d",
    "metadata": {},
    "outputs": [],
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "45cf6192-e13f-401f-9c78-ad23e00b1473",
    "metadata": {},
    "outputs": [
@@ -308,8 +308,16 @@
     }
    ],
    "source": [
-    "grid.save(filepath=\"/glade/derecho/scratch/noraloose/grids/my_grid\", nx=2, ny=5)"
+    "grid.save(filepath=\"/glade/derecho/scratch/noraloose/grids/my_grid\", np_eta=2, np_xi=5)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15e2828b-1a4a-436c-82b7-3fc2539c5ac9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/roms_tools/tests/test_utils.py
+++ b/roms_tools/tests/test_utils.py
@@ -101,7 +101,7 @@ class TestPartitionGrid:
             "s_rho": 100,
             "s_w": 101,
         }
-        assert ds2.sizes == {
+        assert ds4.sizes == {
             "eta_rho": 10,
             "xi_rho": 11,
             "xi_u": 10,
@@ -111,7 +111,7 @@ class TestPartitionGrid:
             "s_rho": 100,
             "s_w": 101,
         }
-        assert ds3.sizes == {
+        assert ds7.sizes == {
             "eta_rho": 11,
             "xi_rho": 11,
             "xi_u": 10,
@@ -121,7 +121,7 @@ class TestPartitionGrid:
             "s_rho": 100,
             "s_w": 101,
         }
-        assert ds4.sizes == {
+        assert ds2.sizes == {
             "eta_rho": 11,
             "xi_rho": 10,
             "xi_u": 10,
@@ -141,7 +141,7 @@ class TestPartitionGrid:
             "s_rho": 100,
             "s_w": 101,
         }
-        assert ds6.sizes == {
+        assert ds8.sizes == {
             "eta_rho": 11,
             "xi_rho": 10,
             "xi_u": 10,
@@ -151,7 +151,7 @@ class TestPartitionGrid:
             "s_rho": 100,
             "s_w": 101,
         }
-        assert ds7.sizes == {
+        assert ds3.sizes == {
             "eta_rho": 11,
             "xi_rho": 11,
             "xi_u": 11,
@@ -161,7 +161,7 @@ class TestPartitionGrid:
             "s_rho": 100,
             "s_w": 101,
         }
-        assert ds8.sizes == {
+        assert ds6.sizes == {
             "eta_rho": 10,
             "xi_rho": 11,
             "xi_u": 11,

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -196,8 +196,8 @@ def partition(
 
     file_numbers = []
     partitioned_datasets = []
-    for j in range(np_xi):
-        for i in range(np_eta):
+    for i in range(np_eta):
+        for j in range(np_xi):
             file_number = j + (i * np_xi)
             file_numbers.append(file_number)
 


### PR DESCRIPTION
This is a follow-up to PR #119. It simply updates the notebook that showcases the partitioning of files - now with the correct parameters `np_eta`, `np_xi`.