### PR TITLE
Tool for partitioning existing NetCDF files

### DIFF
--- a/docs/partition.ipynb
+++ b/docs/partition.ipynb
@@ -11,16 +11,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "fd95437d-4fbb-4cf2-b405-c294f1b122e8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from roms_tools.utils import partition"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "60bb804f-c1ad-4a29-9983-016c9ba51921",
    "metadata": {},
@@ -33,11 +23,25 @@
    "id": "9fe13d86-db59-4ce3-9a5a-3e5c594012fe",
    "metadata": {},
    "source": [
-    "Let's assume we have already saved a global input file to disk, let's call this step 0:\n",
-    "\n",
-    "0. Save global file to disk.\n",
-    "\n",
-    "Here is an example for performing step 0 with `ROMS-Tools` for the grid file. (Note, however, that the `partition` tool does not care whether or whether not `ROMS-Tools` was used to perform step 0.)"
+    "Let's assume we have already saved a global (i.e., non-partitioned) input file to disk. The following function can partition that global file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9ddac10b-eaab-4837-8ada-76abafdf31cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from roms_tools.utils import partition_netcdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cd346fb-49ef-433c-a507-ab6c60e114df",
+   "metadata": {},
+   "source": [
+    "Here is an example for creating and saving a global grid file with `ROMS-Tools`. (Note, however, that `ROMS-Tool`'s `partition_netcdf` tool does not care whether or whether not `ROMS-Tools` was used to create the global file.)"
    ]
   },
   {
@@ -71,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path_to_global_file = \"/glade/derecho/scratch/noraloose/examples/my_grid\""
+    "filepath = \"/glade/derecho/scratch/noraloose/examples/my_grid.nc\""
    ]
   },
   {
@@ -90,7 +94,7 @@
     }
    ],
    "source": [
-    "grid.save(f\"{path_to_global_file}.nc\")"
+    "grid.save(filepath)"
    ]
   },
   {
@@ -98,161 +102,38 @@
    "id": "11a319f2-dcb4-425c-b679-74e38ab66184",
    "metadata": {},
    "source": [
-    "We can now partition the saved file as follows:\n",
+    "We can now partition the saved file. We need to tell the `partition_netcdf` function what domain decomposition to use via the following two parameters:\n",
     "\n",
-    "1. `xr.open_dataset`: Open saved file as xarray Dataset\n",
-    "2. `partition`: Partition the xarray Dataset into `nx` by `ny` spatial tiles\n",
-    "3. `xr.save_mfdataset`: Save the partitioned xarray Datasets to file"
+    "* `np_eta` : The number of partitions along the `eta` direction.\n",
+    "* `np_xi` : The number of partitions along the `xi` direction."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "b6e30499-935a-4078-895c-b0e4cd0b1920",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import xarray as xr"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
    "id": "16a35ce0-9ef6-49b5-8230-46f99dc4709f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = xr.open_dataset(f\"{path_to_global_file}.nc\")  # step 1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "7081fa77-2af5-4642-b879-29c827f3efc7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "file_numbers, partitioned_datasets = partition(ds, np_eta=2, np_xi=5)  # step 2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "811cc34e-e913-4526-a062-b8b6eba5aede",
-   "metadata": {},
-   "source": [
-    "The previous cell returns two lists:\n",
-    "\n",
-    "* `file_numbers` is a list of integers representing the file numbers associated with each partitioned dataset\n",
-    "* `partitioned_datasets` is a list of `xarray.Dataset` objects, each representing a partitioned subdomain of the original dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "946a5e67-1328-4a3c-8931-634718cd7a63",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "file_numbers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b2e0e743-c08c-49ad-97c4-f36586ca9906",
-   "metadata": {},
-   "source": [
-    "For the third step, we have to create a list of paths to which to save each corresponding dataset. This is where the list `file_numbers` comes in handy."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "ab26dd1f-43ec-45f6-b7ac-eb3bc038ffa4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "paths_to_partitioned_files = [\n",
-    "    f\"{path_to_global_file}.{file_number}.nc\" for file_number in file_numbers\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "aa90976d-29d3-480c-84df-2c91f8aa5bd4",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['/glade/derecho/scratch/noraloose/examples/my_grid.0.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.1.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.2.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.3.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.4.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.5.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.6.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.7.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.8.nc',\n",
-       " '/glade/derecho/scratch/noraloose/examples/my_grid.9.nc']"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "paths_to_partitioned_files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "4d103aa2-6fab-4e1a-97a8-1f1a3fbfd193",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "xr.save_mfdataset(partitioned_datasets, paths_to_partitioned_files)  # step 3"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e169095c-1b33-4b64-a589-24ae1f9ebe3c",
-   "metadata": {},
-   "source": [
-    "The previous cell saved the ten partitioned datasets to the indicated location:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "77863475-d447-46cb-a619-89960c1d92a5",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "my_grid.0.nc  my_grid.3.nc  my_grid.6.nc  my_grid.9.nc\n",
-      "my_grid.1.nc  my_grid.4.nc  my_grid.7.nc  my_grid.nc\n",
-      "my_grid.2.nc  my_grid.5.nc  my_grid.8.nc\n"
+      "Saving the following files:\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.0.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.1.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.2.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.3.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.4.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.5.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.6.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.7.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.8.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.9.nc\n"
      ]
     }
    ],
    "source": [
-    "ls /glade/derecho/scratch/noraloose/examples/"
+    "partition_netcdf(filepath, np_eta=2, np_xi=5)"
    ]
   },
   {
@@ -268,12 +149,12 @@
    "id": "42d95865-b527-44d5-a3dd-cf7bc7ccdf70",
    "metadata": {},
    "source": [
-    "Instead of manually going through steps 0, 1, 2, 3 above, we can also tell `ROMS-Tools` to write partitioned files directly."
+    "Instead of first saving a global file and then partitioning the written NetCDF file, we can also tell `ROMS-Tools` to write partitioned files directly. This will skip writing the global file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 7,
    "id": "ca08a3a8-719f-4f64-942a-234d0064400d",
    "metadata": {},
    "outputs": [],
@@ -285,7 +166,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 8,
+   "id": "55fca526-ad69-46d4-bcec-7fde111510b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filepath = \"/glade/derecho/scratch/noraloose/examples/my_grid.nc\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
    "id": "45cf6192-e13f-401f-9c78-ad23e00b1473",
    "metadata": {},
    "outputs": [
@@ -294,21 +185,21 @@
      "output_type": "stream",
      "text": [
       "Saving the following files:\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.0.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.1.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.2.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.3.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.4.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.5.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.6.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.7.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.8.nc\n",
-      "/glade/derecho/scratch/noraloose/grids/my_grid.9.nc\n"
+      "/glade/derecho/scratch/noraloose/examples/my_grid.0.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.1.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.2.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.3.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.4.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.5.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.6.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.7.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.8.nc\n",
+      "/glade/derecho/scratch/noraloose/examples/my_grid.9.nc\n"
      ]
     }
    ],
    "source": [
-    "grid.save(filepath=\"/glade/derecho/scratch/noraloose/grids/my_grid\", np_eta=2, np_xi=5)"
+    "grid.save(filepath, np_eta=2, np_xi=5)"
    ]
   },
   {

--- a/roms_tools/tests/test_utils.py
+++ b/roms_tools/tests/test_utils.py
@@ -1,8 +1,8 @@
 import pytest
-
+from pathlib import Path
 import xarray.testing as xrt
 
-from roms_tools.utils import partition
+from roms_tools.utils import partition, partition_netcdf
 from roms_tools import Grid
 
 
@@ -234,3 +234,17 @@ class TestFileNumbers:
 
         # Check if file_numbers is a continuous range without gaps
         assert set(file_numbers) == set(expected_file_numbers)
+
+
+class TestPartitionNetcdf:
+    def test_partition_netcdf(self, grid, tmp_path):
+        filepath = tmp_path / "test_grid.nc"
+        grid.save(filepath)
+
+        partition_netcdf(filepath, np_eta=3, np_xi=3)
+
+        filepath_str = str(filepath.with_suffix(""))
+        expected_filepath_list = [(filepath_str + f".{index}.nc") for index in range(9)]
+        for expected_filepath in expected_filepath_list:
+            assert Path(expected_filepath).exists()
+            Path(expected_filepath).unlink()


### PR DESCRIPTION
This PR adds a new function `roms_tools.utils.partition_netcdf` which partitions existing NetCDF files (similarly to the fortran `partit`).

You can simply do
```
from roms_tools.utils import partition_netcdf
partition_netcdf(filepath, np_eta=2, np_xi=5)
```

see also the updated documentation

cc @dafyddstephenson 