### PR TITLE
Add PyYAML as required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "packaging",
     "scipy",
     "gcm_filters",
-    "numba"
+    "numba",
+    "PyYAML"
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
Now that the newest version of GCM-Filters (v0.5.0) does not require dask anymore, `PyYAML` (which is a dependency of dask) does not get installed anymore. We need to add it explicitly as a dependency.