### PR TITLE
Clear error messages related to climatology flag

### DIFF
--- a/roms_tools/setup/datasets.py
+++ b/roms_tools/setup/datasets.py
@@ -916,7 +916,7 @@ class CESMDataset(Dataset):
     dim_names: Dict[str, str], optional
         Dictionary specifying the names of dimensions in the dataset.
     climatology : bool
-        Indicates whether the dataset is climatological. Defaults to True.
+        Indicates whether the dataset is climatological. Defaults to False.
 
     Attributes
     ----------
@@ -1005,7 +1005,7 @@ class CESMBGCDataset(CESMDataset):
     dim_names: Dict[str, str], optional
         Dictionary specifying the names of dimensions in the dataset.
     climatology : bool
-        Indicates whether the dataset is climatological. Defaults to True.
+        Indicates whether the dataset is climatological. Defaults to False.
 
     Attributes
     ----------
@@ -1058,7 +1058,7 @@ class CESMBGCDataset(CESMDataset):
         }
     )
 
-    climatology: Optional[bool] = True
+    climatology: Optional[bool] = False
 
     def post_process(self):
         """

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -42,7 +42,7 @@ class InitialConditions(ROMSToolsMixins):
         - "name" (str): Name of the BGC data source (e.g., "CESM_REGRIDDED").
         - "path" (Union[str, Path, List[Union[str, Path]]]): The path to the raw data file(s). Can be a single string (with or without wildcards),
           a single Path object, or a list of strings or Path objects containing multiple files.
-        - "climatology" (bool): Indicates if the BGC data is climatology data. Defaults to True.
+        - "climatology" (bool): Indicates if the BGC data is climatology data. Defaults to False.
     model_reference_date : datetime, optional
         The reference date for the model. Defaults to January 1, 2000.
     use_dask: bool, optional
@@ -62,7 +62,7 @@ class InitialConditions(ROMSToolsMixins):
     ...     bgc_source={
     ...         "name": "CESM_REGRIDDED",
     ...         "path": "bgc_data.nc",
-    ...         "climatology": True,
+    ...         "climatology": False,
     ...     },
     ... )
     """
@@ -155,13 +155,13 @@ class InitialConditions(ROMSToolsMixins):
                 raise ValueError(
                     "`bgc_source` must include a 'path' if it is provided."
                 )
-            # set self.bgc_source["climatology"] to True if not provided
+            # set self.bgc_source["climatology"] to False if not provided
             object.__setattr__(
                 self,
                 "bgc_source",
                 {
                     **self.bgc_source,
-                    "climatology": self.bgc_source.get("climatology", True),
+                    "climatology": self.bgc_source.get("climatology", False),
                 },
             )
 

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -329,7 +329,7 @@ def get_time_type(data_array: xr.DataArray) -> str:
         cftime.DatetimeJulian,
         cftime.DatetimeGregorian,
         cftime.Datetime360Day,
-        cftime.DatetimeProlepticGregorian
+        cftime.DatetimeProlepticGregorian,
     )
 
     # Check if any of the coordinate values are of cftime, datetime, or integer type
@@ -351,6 +351,7 @@ def get_time_type(data_array: xr.DataArray) -> str:
 
     # Handle unexpected types
     raise TypeError("DataArray values must be of type numpy.ndarray or list.")
+
 
 def convert_cftime_to_datetime(data_array: np.ndarray) -> np.ndarray:
     """

--- a/roms_tools/tests/test_setup/test_datasets.py
+++ b/roms_tools/tests/test_setup/test_datasets.py
@@ -2,7 +2,7 @@ import pytest
 from datetime import datetime
 import numpy as np
 import xarray as xr
-from roms_tools.setup.datasets import Dataset, GLORYSDataset, ERA5Correction
+from roms_tools.setup.datasets import Dataset, GLORYSDataset, ERA5Correction, CESMBGCDataset
 from roms_tools.setup.download import download_test_data
 from pathlib import Path
 
@@ -448,3 +448,29 @@ def test_time_validation(use_dask):
             end_time="dummy",
             use_dask=use_dask,
         )
+
+def test_climatology_error(use_dask):
+    
+    fname = download_test_data("GLORYS_NA_2012.nc")
+
+    with pytest.raises(ValueError, match=f"The dataset contains 2 time steps, but the climatology flag is set to True, which requires exactly 12 time steps."):
+        GLORYSDataset(
+            filename=fname,
+            start_time=datetime(2012, 1, 1),
+            end_time=datetime(2013, 1, 1),
+            climatology=True,
+            use_dask=use_dask,
+        )
+
+    fname_bgc = download_test_data("CESM_regional_coarse_test_data_climatology.nc")
+    
+    with pytest.raises(ValueError, match=f"The dataset contains integer time values, which are only supported when the climatology flag is set to True. However, your climatology flag is set to False."):
+    
+        CESMBGCDataset(
+            filename=fname_bgc,
+            start_time=datetime(2012, 1, 1),
+            end_time=datetime(2013, 1, 1),
+            climatology=False,
+            use_dask=use_dask,
+        )
+

--- a/roms_tools/tests/test_setup/test_datasets.py
+++ b/roms_tools/tests/test_setup/test_datasets.py
@@ -2,7 +2,12 @@ import pytest
 from datetime import datetime
 import numpy as np
 import xarray as xr
-from roms_tools.setup.datasets import Dataset, GLORYSDataset, ERA5Correction, CESMBGCDataset
+from roms_tools.setup.datasets import (
+    Dataset,
+    GLORYSDataset,
+    ERA5Correction,
+    CESMBGCDataset,
+)
 from roms_tools.setup.download import download_test_data
 from pathlib import Path
 
@@ -449,11 +454,15 @@ def test_time_validation(use_dask):
             use_dask=use_dask,
         )
 
+
 def test_climatology_error(use_dask):
-    
+
     fname = download_test_data("GLORYS_NA_2012.nc")
 
-    with pytest.raises(ValueError, match=f"The dataset contains 2 time steps, but the climatology flag is set to True, which requires exactly 12 time steps."):
+    with pytest.raises(
+        ValueError,
+        match="The dataset contains 2 time steps, but the climatology flag is set to True, which requires exactly 12 time steps.",
+    ):
         GLORYSDataset(
             filename=fname,
             start_time=datetime(2012, 1, 1),
@@ -463,9 +472,12 @@ def test_climatology_error(use_dask):
         )
 
     fname_bgc = download_test_data("CESM_regional_coarse_test_data_climatology.nc")
-    
-    with pytest.raises(ValueError, match=f"The dataset contains integer time values, which are only supported when the climatology flag is set to True. However, your climatology flag is set to False."):
-    
+
+    with pytest.raises(
+        ValueError,
+        match="The dataset contains integer time values, which are only supported when the climatology flag is set to True. However, your climatology flag is set to False.",
+    ):
+
         CESMBGCDataset(
             filename=fname_bgc,
             start_time=datetime(2012, 1, 1),
@@ -473,4 +485,3 @@ def test_climatology_error(use_dask):
             climatology=False,
             use_dask=use_dask,
         )
-

--- a/roms_tools/tests/test_setup/test_fill.py
+++ b/roms_tools/tests/test_setup/test_fill.py
@@ -93,7 +93,7 @@ def cesm_surface_bgc_data(request, use_dask):
         filename=fname,
         start_time=datetime(2012, 1, 1),
         end_time=datetime(2013, 1, 1),
-        climatology=True,
+        climatology=False,
         use_dask=use_dask,
     )
     data.post_process()

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -143,7 +143,7 @@ def test_initial_conditions_default_bgc_climatology(example_grid, use_dask):
         use_dask=use_dask,
     )
 
-    assert initial_conditions.bgc_source["climatology"] is True
+    assert initial_conditions.bgc_source["climatology"] is False
 
 
 def test_interpolation_from_climatology(


### PR DESCRIPTION
This PR

* sets the climatology flag always to `False` by default
* implements clear error messages related to climatology flag (closes #137)

and tests these two new features.