### PR TITLE
Fix python version when building the docs

### DIFF
--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -17,8 +17,8 @@ jobs:
           cache-environment: true
           micromamba-version: 'latest'
           environment-file: ci/environment.yml
-          create-args: |
-            python=${{ matrix.python-version }}
+      - name: Conda info
+        run: conda info
       - name: Install roms-tools
         shell: micromamba-shell {0}
         run: |

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -20,7 +20,7 @@ jobs:
           cache-downloads: true
           cache-environment: true
           micromamba-version: 'latest'
-          environment-file: ci/environment.yml
+          environment-file: docs/environment.yml
           create-args: |
             python=${{ matrix.python-version }}
           cache-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   docs:
+    name: ${{ matrix.python-version }}-build-without-dask
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Create conda environment
@@ -17,6 +21,9 @@ jobs:
           cache-environment: true
           micromamba-version: 'latest'
           environment-file: ci/environment.yml
+          create-args: |
+            python=${{ matrix.python-version }}
+          cache-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}
       - name: Conda info
         run: conda info
       - name: Install roms-tools

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs:
-    name: ${{ matrix.python-version }}-build-without-dask
+    name: ${{ matrix.python-version }}-build-docs
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -7,11 +7,7 @@ on:
 
 jobs:
   docs:
-    name: ${{ matrix.python-version }}-build-docs
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Create conda environment
@@ -21,9 +17,6 @@ jobs:
           cache-environment: true
           micromamba-version: 'latest'
           environment-file: docs/environment.yml
-          create-args: |
-            python=${{ matrix.python-version }}
-          cache-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}
       - name: Conda info
         run: conda info
       - name: Install roms-tools

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,7 @@ sphinx:
    configuration: docs/conf.py
 
 conda:
-    environment: ci/environment.yml
+    environment: docs/environment.yml
 
 # Python dependencies and install method
 python:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,4 +1,4 @@
-name: romstools
+name: romstools-test
 channels:
   - conda-forge
   - nodefaults
@@ -12,10 +12,3 @@ dependencies:
   - black
   - pre-commit
   - coverage
-  # docs
-  - sphinx
-  - nbsphinx
-  - sphinx-book-theme
-  - sphinxcontrib-bibtex
-  # for running jupyter notebooks
-  - ipykernel

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -49,4 +49,3 @@ Then navigate to the docs folder and build the docs via::
     make html
 
 You can now open ``docs/_build/html/index.html`` in a web browser.
-

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,52 @@
+Contributor Guide
+##################
+
+Running the tests
+=================
+Install and activate the following conda environment::
+
+    cd roms-tools
+    conda env create -f ci/environment.yml
+    conda activate romstools-test
+    pip install -e ".[dask]"
+
+You can check the functionality of the ROMS-Tools code by running the test suite::
+
+    conda activate romstools-test
+    pytest
+
+
+Contributing code
+=================
+
+If you have written new code, you can run the tests as described in the previous step. You will likely have to iterate here several times until all tests pass.
+The next step is to make sure that the code is formatted properly. Activate the environment::
+
+    conda activate romstools-test
+
+You can now run all the linters with::
+
+    pre-commit run --all-files
+
+Some things will automatically be reformatted, others need manual fixes. Follow the instructions in the terminal until all checks pass.
+Once you got everything to pass, you can stage and commit your changes and push them to the remote github repository.
+
+
+Building the documentation locally
+==================================
+
+Install and activate the following conda environment::
+
+    cd roms-tools
+    conda env create -f docs/environment.yml
+    conda activate romstools-docs
+    pip install -e ".[dask]"
+
+Then navigate to the docs folder and build the docs via::
+
+    cd docs
+    make fresh
+    make html
+
+You can now open ``docs/_build/html/index.html`` in a web browser.
+

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -42,9 +42,10 @@ Install and activate the following conda environment::
     conda activate romstools-docs
     pip install -e ".[dask]"
 
-Then navigate to the docs folder and build the docs via::
+Navigate to the docs folder and build the docs with the activated environment::
 
     cd docs
+    conda activate romstools-docs
     make fresh
     make html
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,12 @@
+name: romstools-docs
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.12
+  - sphinx
+  - nbsphinx
+  - sphinx-book-theme
+  - sphinxcontrib-bibtex
+  # for running jupyter notebooks
+  - ipykernel

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,9 +55,9 @@ This Python package is inspired by the `UCLA MATLAB tools <https://github.com/nm
 
 .. toctree::
    :maxdepth: 1
-   :caption: Community
+   :caption: Contributor Guide
 
-   support
+   contributing
 
 .. toctree::
    :maxdepth: 1

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,4 +30,3 @@ If you want to use ROMS-Tools together with dask (which we recommend), you can
 install ROMS-Tools along with the additional dependency via::
 
     pip install ".[dask]"
-

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,57 +22,12 @@ To obtain the latest development version, first clone
     git clone https://github.com/CWorthy-ocean/roms-tools.git
     cd roms-tools
 
-Next, install and activate the following conda environment::
+Then, install ROMS-Tools via::
 
-    conda env create -f ci/environment.yml
-    conda activate romstools
-
-Finally, install ROMS-Tools in the same environment::
-
-    pip install -e .
+    pip install .
 
 If you want to use ROMS-Tools together with dask (which we recommend), you can
 install ROMS-Tools along with the additional dependency via::
 
-    pip install -e .[dask]
+    pip install ".[dask]"
 
-Running the tests
-=================
-
-You can check the functionality of the ROMS-Tools code by running the test suite::
-
-    conda activate romstools
-    cd roms-tools
-    pytest
-
-
-Contributing code
-=================
-
-If you have written new code, you can run the tests as described in the previous step. You will likely have to iterate here several times until all tests pass.
-The next step is to make sure that the code is formatted properly. Activate the environment::
-
-    conda activate romstools
-
-You can now run all the linters with::
-
-    pre-commit run --all-files
-
-Some things will automatically be reformatted, others need manual fixes. Follow the instructions in the terminal until all checks pass.
-Once you got everything to pass, you can stage and commit your changes and push them to the remote github repository.
-
-
-Building the documentation locally
-==================================
-
-Activate the environment::
-
-    conda activate romstools
-
-Then navigate to the docs folder and build the docs via::
-
-    cd docs
-    make fresh
-    make html
-
-You can now open ``docs/_build/html/index.html`` in a web browser.

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,7 +1,0 @@
-Getting Support
-###############
-
-If you think there is a bug in the code or have any questions about using roms-tools,
-please
-`submit an issue <https://github.com/CWorthy-ocean/roms-tools/issues/new>`_,
-with a sufficient description of the problem or question.


### PR DESCRIPTION
Closes #166.

This PR separates the existing conda environment into two conda environments:
* `ci/environment.yml` --> romstools-test for testing
* `docs/environment.yml` --> romstools-docs for building the docs

In the second environment, we fix the python version to 3.12 to avoid the issue reported in #166.