### PR TITLE
Pathlib again

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,12 @@
 
 ### Bugfixes
 
+## v2.2.1
+
+### Bugfixes
+
+* Correctly write Pathlib `bgc_source` to YAML file ([#215](https://github.com/CWorthy-ocean/roms-tools/pull/215))
+
 ## v2.2.0
 
 ### Bugfixes

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -1080,8 +1080,10 @@ def _to_yaml(forcing_object, filepath: Union[str, Path]) -> None:
         grid_yaml_data = {**parent_grid_yaml_data, **child_grid_yaml_data}
 
     # Ensure forcing_object.source.path is a string (convert if it's a pathlib object)
-    if hasattr(forcing_object, "source") and "path" in forcing_object.source:
+    if hasattr(forcing_object, "source") and forcing_object.source is not None and "path" in forcing_object.source:
         forcing_object.source["path"] = str(forcing_object.source["path"])
+    if hasattr(forcing_object, "bgc_source") and forcing_object.bgc_source is not None and "path" in forcing_object.bgc_source:
+        forcing_object.bgc_source["path"] = str(forcing_object.bgc_source["path"])
 
     # Step 2: Get ROMS Tools version
     # Fetch the version of the 'roms-tools' package for inclusion in the YAML header

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -1080,9 +1080,17 @@ def _to_yaml(forcing_object, filepath: Union[str, Path]) -> None:
         grid_yaml_data = {**parent_grid_yaml_data, **child_grid_yaml_data}
 
     # Ensure forcing_object.source.path is a string (convert if it's a pathlib object)
-    if hasattr(forcing_object, "source") and forcing_object.source is not None and "path" in forcing_object.source:
+    if (
+        hasattr(forcing_object, "source")
+        and forcing_object.source is not None
+        and "path" in forcing_object.source
+    ):
         forcing_object.source["path"] = str(forcing_object.source["path"])
-    if hasattr(forcing_object, "bgc_source") and forcing_object.bgc_source is not None and "path" in forcing_object.bgc_source:
+    if (
+        hasattr(forcing_object, "bgc_source")
+        and forcing_object.bgc_source is not None
+        and "path" in forcing_object.bgc_source
+    ):
         forcing_object.bgc_source["path"] = str(forcing_object.bgc_source["path"])
 
     # Step 2: Get ROMS Tools version

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -250,7 +250,9 @@ def test_initial_conditions_save(
                 expected_filepath.unlink()
 
 
-def test_roundtrip_yaml(initial_conditions_with_bgc_from_climatology, tmp_path, use_dask):
+def test_roundtrip_yaml(
+    initial_conditions_with_bgc_from_climatology, tmp_path, use_dask
+):
     """Test that creating an InitialConditions object, saving its parameters to yaml
     file, and re-opening yaml file creates the same object."""
 
@@ -267,7 +269,9 @@ def test_roundtrip_yaml(initial_conditions_with_bgc_from_climatology, tmp_path, 
             filepath, use_dask=use_dask
         )
 
-        assert initial_conditions_with_bgc_from_climatology == initial_conditions_from_file
+        assert (
+            initial_conditions_with_bgc_from_climatology == initial_conditions_from_file
+        )
 
         filepath = Path(filepath)
         filepath.unlink()

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -250,7 +250,7 @@ def test_initial_conditions_save(
                 expected_filepath.unlink()
 
 
-def test_roundtrip_yaml(initial_conditions, tmp_path, use_dask):
+def test_roundtrip_yaml(initial_conditions_with_bgc_from_climatology, tmp_path, use_dask):
     """Test that creating an InitialConditions object, saving its parameters to yaml
     file, and re-opening yaml file creates the same object."""
 
@@ -261,13 +261,13 @@ def test_roundtrip_yaml(initial_conditions, tmp_path, use_dask):
         str(tmp_path / file_str),
     ]:  # test for Path object and str
 
-        initial_conditions.to_yaml(filepath)
+        initial_conditions_with_bgc_from_climatology.to_yaml(filepath)
 
         initial_conditions_from_file = InitialConditions.from_yaml(
             filepath, use_dask=use_dask
         )
 
-        assert initial_conditions == initial_conditions_from_file
+        assert initial_conditions_with_bgc_from_climatology == initial_conditions_from_file
 
         filepath = Path(filepath)
         filepath.unlink()


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This PR is a follow-up to #212: now also the `bgc_source` gets correctly written to YAML if it uses pathlib.

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
