### PR TITLE
Make YAMLs safe for list of files

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,8 @@
 
 ### Bugfixes
 
+* Correctly handle list of files in `source` and `bgc_source` in YAML files ([#218](https://github.com/CWorthy-ocean/roms-tools/pull/218))
+
 ## v2.2.1
 
 ### Bugfixes

--- a/roms_tools/tests/test_setup/test_utils.py
+++ b/roms_tools/tests/test_setup/test_utils.py
@@ -1,7 +1,11 @@
+from roms_tools import Grid, BoundaryForcing
 from roms_tools.setup.utils import interpolate_from_climatology
 from roms_tools.setup.datasets import ERA5Correction
 from roms_tools.setup.download import download_test_data
 import xarray as xr
+import pytest
+from datetime import datetime
+from pathlib import Path
 
 
 def test_interpolate_from_climatology(use_dask):
@@ -14,3 +18,54 @@ def test_interpolate_from_climatology(use_dask):
 
     interpolated_field = interpolate_from_climatology(field, "time", era5_times)
     assert len(interpolated_field.time) == len(era5_times)
+
+
+# Test yaml roundtrip with multiple source files
+@pytest.fixture()
+def boundary_forcing_from_multiple_source_files(request, use_dask):
+    """Fixture for creating a BoundaryForcing object."""
+
+    grid = Grid(
+        nx=5,
+        ny=5,
+        size_x=100,
+        size_y=100,
+        center_lon=-8,
+        center_lat=60,
+        rot=10,
+        N=3,  # number of vertical levels
+    )
+
+    fname1 = Path(download_test_data("GLORYS_NA_20120101.nc"))
+    fname2 = Path(download_test_data("GLORYS_NA_20121231.nc"))
+
+    return BoundaryForcing(
+        grid=grid,
+        start_time=datetime(2011, 1, 1),
+        end_time=datetime(2013, 1, 1),
+        source={"name": "GLORYS", "path": [fname1, fname2]},
+        use_dask=use_dask,
+    )
+
+
+def test_roundtrip_yaml(
+    boundary_forcing_from_multiple_source_files, request, tmp_path, use_dask
+):
+    """Test that creating a BoundaryForcing object, saving its parameters to yaml file,
+    and re-opening yaml file creates the same object."""
+
+    # Create a temporary filepath using the tmp_path fixture
+    file_str = "test_yaml"
+    for filepath in [
+        tmp_path / file_str,
+        str(tmp_path / file_str),
+    ]:  # test for Path object and str
+
+        boundary_forcing_from_multiple_source_files.to_yaml(filepath)
+
+        bdry_forcing_from_file = BoundaryForcing.from_yaml(filepath, use_dask=use_dask)
+
+        assert boundary_forcing_from_multiple_source_files == bdry_forcing_from_file
+
+        filepath = Path(filepath)
+        filepath.unlink()


### PR DESCRIPTION
This PR fixes a bug which was introduced by #212 and #215. When the user specifies a list of files as their `source`, the whole list was converted to a string, rather than each list element individually. This is now fixed, and verified by a test.

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
