### PR TITLE
Improve performance for surface forcing

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,9 +10,14 @@
 
 ### Internal Changes
 
+* Parallelize computation of radiation correction, leading to a hugely improved memory footprint for surface forcing generation ([#227](https://github.com/CWorthy-ocean/roms-tools/pull/227))
+* For computation of radiation correction, swap order of temporal and spatial interpolation to further improve memory footprint ([#227](https://github.com/CWorthy-ocean/roms-tools/pull/227))
+
 ### Documentation
 
 ### Bugfixes
+
+* Fix bug in validation step for surface forcing ([#227](https://github.com/CWorthy-ocean/roms-tools/pull/227))
 
 ## v2.3.0
 

--- a/roms_tools/setup/datasets.py
+++ b/roms_tools/setup/datasets.py
@@ -2058,6 +2058,7 @@ def _select_relevant_times(
                 )
             if not end_time:
                 # Interpolate from climatology for initial conditions
+                ds["time"] = ds["time"].dt.days
                 ds = interpolate_from_climatology(ds, time_dim, start_time)
         else:
             time_type = get_time_type(ds[time_dim])

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -275,6 +275,8 @@ class SurfaceForcing:
             coords_correction, straddle=self.target_coords["straddle"]
         )
         correction_data.ds["mask"] = data.ds["mask"]  # use mask from ERA5 data
+        correction_data.ds["time"] = correction_data.ds["time"].dt.days
+
         correction_data.apply_lateral_fill()
         # regrid
         lateral_regrid = LateralRegrid(self.target_coords, correction_data.dim_names)

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -284,12 +284,17 @@ class SurfaceForcing:
             correction_data.ds[correction_data.var_names["swr_corr"]]
         )
 
-        # temporal interpolation
-        corr_factor = interpolate_from_climatology(
-            corr_factor,
-            correction_data.dim_names["time"],
-            time=processed_fields["swrad"].time,
-        )
+        # Perform temporal interpolation for each time slice to enforce chunking in time.
+        # This reduces memory usage by processing one time step at a time.
+        # The interpolated slices are then concatenated along the "time" dimension.
+        corr_factor = xr.concat([
+            interpolate_from_climatology(
+                corr_factor,
+                correction_data.dim_names["time"],
+                time=time
+            )
+            for time in processed_fields["swrad"].time
+        ], dim="time")
 
         processed_fields["swrad"] = processed_fields["swrad"] * corr_factor
 

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -284,17 +284,25 @@ class SurfaceForcing:
             correction_data.ds[correction_data.var_names["swr_corr"]]
         )
 
-        # Perform temporal interpolation for each time slice to enforce chunking in time.
-        # This reduces memory usage by processing one time step at a time.
-        # The interpolated slices are then concatenated along the "time" dimension.
-        corr_factor = xr.concat([
-            interpolate_from_climatology(
+        if self.use_dask:
+            # Perform temporal interpolation for each time slice to enforce chunking in time.
+            # This reduces memory usage by processing one time step at a time.
+            # The interpolated slices are then concatenated along the "time" dimension.
+            corr_factor = xr.concat(
+                [
+                    interpolate_from_climatology(
+                        corr_factor, correction_data.dim_names["time"], time=time
+                    )
+                    for time in processed_fields["swrad"].time
+                ],
+                dim="time",
+            )
+        else:
+            corr_factor = interpolate_from_climatology(
                 corr_factor,
                 correction_data.dim_names["time"],
-                time=time
+                time=processed_fields["swrad"].time,
             )
-            for time in processed_fields["swrad"].time
-        ], dim="time")
 
         processed_fields["swrad"] = processed_fields["swrad"] * corr_factor
 

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -238,14 +238,14 @@ class SurfaceForcing:
                 "qair": {**default_info, "validate": True},
                 "rain": {**default_info, "validate": False},
                 "uwnd": {
-                    "location": "u",
+                    "location": "rho",
                     "is_vector": True,
                     "vector_pair": "vwnd",
                     "is_3d": False,
                     "validate": True,
                 },
                 "vwnd": {
-                    "location": "v",
+                    "location": "rho",
                     "is_vector": True,
                     "vector_pair": "uwnd",
                     "is_3d": False,
@@ -357,12 +357,8 @@ class SurfaceForcing:
 
         for var_name in ds.data_vars:
             if self.variable_info[var_name]["validate"]:
-                if self.variable_info[var_name]["location"] == "rho":
-                    mask = self.target_coords["mask"]
-                elif self.variable_info[var_name]["location"] == "u":
-                    mask = self.target_coords["mask_u"]
-                elif self.variable_info[var_name]["location"] == "v":
-                    mask = self.target_coords["mask_v"]
+                # all variables are at rho-points
+                mask = self.target_coords["mask"]
                 nan_check(ds[var_name].isel(time=0), mask)
 
     def _add_global_metadata(self, ds=None):

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -200,6 +200,7 @@ def interpolate_from_climatology(
             for var, data_array in field.data_vars.items()
         }
         return xr.Dataset(interpolated_data_vars, attrs=field.attrs)
+
     else:
         raise TypeError("Input 'field' must be an xarray.DataArray or xarray.Dataset.")
 
@@ -633,8 +634,6 @@ def get_target_coords(grid, use_coarse_grid=False):
         mask = grid.ds.get("mask_coarse")
         if mask is not None:
             mask = mask.rename({"eta_coarse": "eta_rho", "xi_coarse": "xi_rho"})
-            mask_u = interpolate_from_rho_to_u(mask, method="multiplicative")
-            mask_v = interpolate_from_rho_to_v(mask, method="multiplicative")
 
         lat_psi = grid.ds.get("lat_psi_coarse")
         lon_psi = grid.ds.get("lon_psi_coarse")
@@ -644,8 +643,6 @@ def get_target_coords(grid, use_coarse_grid=False):
         lon = grid.ds.lon_rho
         angle = grid.ds.angle
         mask = grid.ds.get("mask_rho")
-        mask_u = grid.ds.get("mask_u")
-        mask_v = grid.ds.get("mask_v")
         lat_psi = grid.ds.get("lat_psi")
         lon_psi = grid.ds.get("lon_psi")
 
@@ -668,8 +665,6 @@ def get_target_coords(grid, use_coarse_grid=False):
         "lon_psi": lon_psi,
         "angle": angle,
         "mask": mask,
-        "mask_u": mask_u,
-        "mask_v": mask_v,
         "straddle": straddle,
     }
 

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -130,8 +130,7 @@ def interpolate_from_climatology(
     time_dim_name: str,
     time: Union[xr.DataArray, pd.DatetimeIndex],
 ) -> Union[xr.DataArray, xr.Dataset]:
-    """
-    Temporally interpolates a field based on specified time points.
+    """Temporally interpolates a field based on specified time points.
 
     This function performs temporal interpolation on the input `field` to match the provided `time` values.
     If the input `field` is an `xarray.Dataset`, the interpolation is applied to all its data variables individually.
@@ -161,8 +160,8 @@ def interpolate_from_climatology(
       For example, you can preprocess the time as follows:
 
       >>> field["time"] = field["time"].dt.dayofyear
-
     """
+
     def interpolate_single_field(data_array: xr.DataArray) -> xr.DataArray:
 
         if isinstance(time, xr.DataArray):

--- a/roms_tools/tests/test_setup/test_utils.py
+++ b/roms_tools/tests/test_setup/test_utils.py
@@ -15,6 +15,7 @@ def test_interpolate_from_climatology(use_dask):
 
     climatology = ERA5Correction(use_dask=use_dask)
     field = climatology.ds["ssr_corr"]
+    field["time"] = field["time"].dt.days
 
     interpolated_field = interpolate_from_climatology(field, "time", era5_times)
     assert len(interpolated_field.time) == len(era5_times)


### PR DESCRIPTION
This PR makes some changes that lead to major performance gains for the surface forcing creation, in particular in terms of memory footprint. 

- [x] Parallelize computation of radiation correction (when `use_dask = True`), which leads to a huge improvement of the memory footprint, both during the validation step and the saving step (see #201). Closes #225.
- [x] For radiation correction, swap order of temporal and spatial interpolation: first temporal, then spatial. This somehow leads to a further improved memory footprint. E.g., performance for initialization of surface forcing with `correct_radiation = True`, `use_dask = True`, `bypass_validation = False`:
* first spatial, then temporal (old)
```
peak memory: 13589.34 MiB, increment: 13049.53 MiB
CPU times: user 20.2 s, sys: 3.85 s, total: 24 s
Wall time: 26.7 s
```
* first temporal, then spatial (new)
```
peak memory: 1343.37 MiB, increment: 803.54 MiB
CPU times: user 11 s, sys: 670 ms, total: 11.7 s
Wall time: 11.6 s
```
- [x] Fix bug in validation step: Always use rho-mask, which is the correct one.

Checklist:

- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`