### PR TITLE
Better handling of `start_time = None` and `end_time = None`

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,10 +6,13 @@
 
 ### Breaking Changes
 
+* Write and read the parameter `bypass_validation` to/from YAML ([#249](https://github.com/CWorthy-ocean/roms-tools/pull/249))
+
 ### Internal Changes
 
 * Enforce double precision on source data to ensure reproducible results ([#244](https://github.com/CWorthy-ocean/roms-tools/pull/244))
 * Results produced with vs. without Dask in test suite now pass with `xr.testing.assert_equal` confirming reproducibility ([#244](https://github.com/CWorthy-ocean/roms-tools/pull/244))
+* Document the option for `start_time = None` and `end_time = None` in the docstrings for `BoundaryForcing` and `SurfaceForcing`, specifying that when both are `None`, no time filtering is applied to the data. Also, ensure a warning is raised in this case to inform the user. ([#249](https://github.com/CWorthy-ocean/roms-tools/pull/249))
 
 ### Documentation
 

--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -967,7 +967,6 @@ class BoundaryForcing:
         cls,
         filepath: Union[str, Path],
         use_dask: bool = False,
-        bypass_validation: bool = False,
     ) -> "BoundaryForcing":
         """Create an instance of the BoundaryForcing class from a YAML file.
 
@@ -977,10 +976,6 @@ class BoundaryForcing:
             The path to the YAML file from which the parameters will be read.
         use_dask: bool, optional
             Indicates whether to use dask for processing. If True, data is processed with dask; if False, data is processed eagerly. Defaults to False.
-        bypass_validation: bool, optional
-            Indicates whether to skip validation checks in the processed data. When set to True,
-            the validation process that ensures no NaN values exist at wet points
-            in the processed dataset is bypassed. Defaults to False.
 
         Returns
         -------
@@ -993,9 +988,7 @@ class BoundaryForcing:
         params = _from_yaml(cls, filepath)
 
         # Create and return an instance of InitialConditions
-        return cls(
-            grid=grid, **params, use_dask=use_dask, bypass_validation=bypass_validation
-        )
+        return cls(grid=grid, **params, use_dask=use_dask)
 
 
 def apply_1d_horizontal_fill(data_array: xr.DataArray) -> xr.DataArray:

--- a/roms_tools/setup/datasets.py
+++ b/roms_tools/setup/datasets.py
@@ -35,10 +35,11 @@ class Dataset:
         The path to the data file(s). Can be a single string (with or without wildcards), a single Path object,
         or a list of strings or Path objects containing multiple files.
     start_time : Optional[datetime], optional
-        The start time for selecting relevant data. If not provided, the data is not filtered by start time.
+        Start time for selecting relevant data. If not provided, no time-based filtering is applied.
     end_time : Optional[datetime], optional
-        The end time for selecting relevant data. If not provided, only data at the start_time is selected if start_time is provided,
-        or no filtering is applied if start_time is not provided.
+        End time for selecting relevant data. If not provided, the dataset selects the time entry
+        closest to `start_time` within the range `[start_time, start_time + 24 hours]`.
+        If `start_time` is also not provided, no time-based filtering is applied.
     dim_names: Dict[str, str], optional
         Dictionary specifying the names of dimensions in the dataset.
     var_names: Dict[str, str]
@@ -2053,7 +2054,7 @@ def _check_dataset(
 
 
 def _select_relevant_times(
-    ds, time_dim, start_time=None, end_time=None, climatology=False
+    ds, time_dim, start_time, end_time=None, climatology=False
 ) -> xr.Dataset:
     """Select a subset of the dataset based on the specified time range.
 
@@ -2070,11 +2071,10 @@ def _select_relevant_times(
         The input dataset to be filtered. Must contain a time dimension.
     time_dim: str
         Name of time dimension.
-    start_time : Optional[datetime], optional
-        The start time for selecting relevant data. If not provided, the data is not filtered by start time.
+    start_time : datetime
+        The start time for selecting relevant data.
     end_time : Optional[datetime], optional
-        The end time for selecting relevant data. If not provided, only data at the start_time is selected if start_time is provided,
-        or no filtering is applied if start_time is not provided.
+        The end time for selecting relevant data. If not provided, only data at the start_time is selected if start_time is provided.
     climatology : bool
         Indicates whether the dataset is climatological. Defaults to False.
 

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -898,7 +898,6 @@ class InitialConditions:
         cls,
         filepath: Union[str, Path],
         use_dask: bool = False,
-        bypass_validation: bool = False,
     ) -> "InitialConditions":
         """Create an instance of the InitialConditions class from a YAML file.
 
@@ -908,10 +907,6 @@ class InitialConditions:
             The path to the YAML file from which the parameters will be read.
         use_dask: bool, optional
             Indicates whether to use dask for processing. If True, data is processed with dask; if False, data is processed eagerly. Defaults to False.
-        bypass_validation: bool, optional
-            Indicates whether to skip validation checks in the processed data. When set to True,
-            the validation process that ensures no NaN values exist at wet points
-            in the processed dataset is bypassed. Defaults to False.
 
         Returns
         -------
@@ -926,5 +921,4 @@ class InitialConditions:
             grid=grid,
             **initial_conditions_params,
             use_dask=use_dask,
-            bypass_validation=bypass_validation,
         )

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -234,6 +234,11 @@ class InitialConditions:
         return processed_fields
 
     def _input_checks(self):
+        # Check that ini_time is not None
+        if self.ini_time is None:
+            raise ValueError(
+                "`ini_time` must be a valid datetime object and cannot be None."
+            )
 
         if "name" not in self.source.keys():
             raise ValueError("`source` must include a 'name'.")

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -6,7 +6,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from pathlib import Path
 import logging
-from typing import Dict, Union, List
+from typing import Dict, Union, List, Optional
 from roms_tools import Grid
 from roms_tools.utils import save_datasets
 from roms_tools.regrid import LateralRegrid
@@ -38,10 +38,14 @@ class SurfaceForcing:
     ----------
     grid : Grid
         Object representing the grid information.
-    start_time : datetime
-        Start time of the desired surface forcing data.
-    end_time : datetime
-        End time of the desired surface forcing data.
+    start_time : datetime, optional
+        The start time of the desired surface forcing data. This time is used to filter the dataset
+        to include only records on or after this time, with a single record at or before this time.
+        If no time filtering is desired, set it to None. Default is None.
+    end_time : datetime, optional
+        The end time of the desired surface forcing data. This time is used to filter the dataset
+        to include only records on or before this time, with a single record at or after this time.
+        If no time filtering is desired, set it to None. Default is None.
     source : Dict[str, Union[str, Path, List[Union[str, Path]]], bool]
         Dictionary specifying the source of the surface forcing data. Keys include:
 
@@ -90,8 +94,8 @@ class SurfaceForcing:
     """
 
     grid: Grid
-    start_time: datetime
-    end_time: datetime
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None
     source: Dict[str, Union[str, Path, List[Union[str, Path]]]]
     type: str = "physics"
     correct_radiation: bool = True
@@ -168,6 +172,18 @@ class SurfaceForcing:
         object.__setattr__(self, "ds", ds)
 
     def _input_checks(self):
+        # Check that start_time and end_time are both None or none of them is
+        if (self.start_time is None) != (self.end_time is None):
+            raise ValueError(
+                "Both `start_time` and `end_time` must be provided together as datetime objects or both should be None."
+            )
+
+        # Trigger a warning if both are None
+        if self.start_time is None and self.end_time is None:
+            logging.warning(
+                "Both `start_time` and `end_time` are None. No time filtering will be applied to the source data."
+            )
+
         # Validate the 'type' parameter
         if self.type not in ["physics", "bgc"]:
             raise ValueError("`type` must be either 'physics' or 'bgc'.")

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -606,7 +606,6 @@ class SurfaceForcing:
         cls,
         filepath: Union[str, Path],
         use_dask: bool = False,
-        bypass_validation: bool = False,
     ) -> "SurfaceForcing":
         """Create an instance of the SurfaceForcing class from a YAML file.
 
@@ -616,10 +615,6 @@ class SurfaceForcing:
             The path to the YAML file from which the parameters will be read.
         use_dask: bool, optional
             Indicates whether to use dask for processing. If True, data is processed with dask; if False, data is processed eagerly. Defaults to False.
-        bypass_validation: bool, optional
-            Indicates whether to skip validation checks in the processed data. When set to True,
-            the validation process that ensures no NaN values exist at wet points
-            in the processed dataset is bypassed. Defaults to False.
 
         Returns
         -------
@@ -631,6 +626,4 @@ class SurfaceForcing:
         grid = Grid.from_yaml(filepath)
         params = _from_yaml(cls, filepath)
 
-        return cls(
-            grid=grid, **params, use_dask=use_dask, bypass_validation=bypass_validation
-        )
+        return cls(grid=grid, **params, use_dask=use_dask)

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -416,7 +416,6 @@ class TidalForcing:
         cls,
         filepath: Union[str, Path],
         use_dask: bool = False,
-        bypass_validation: bool = False,
     ) -> "TidalForcing":
         """Create an instance of the TidalForcing class from a YAML file.
 
@@ -426,10 +425,6 @@ class TidalForcing:
             The path to the YAML file from which the parameters will be read.
         use_dask: bool, optional
             Indicates whether to use dask for processing. If True, data is processed with dask; if False, data is processed eagerly. Defaults to False.
-        bypass_validation: bool, optional
-            Indicates whether to skip validation checks in the processed data. When set to True,
-            the validation process that ensures no NaN values exist at wet points
-            in the processed dataset is bypassed. Defaults to False.
 
         Returns
         -------
@@ -444,7 +439,6 @@ class TidalForcing:
             grid=grid,
             **tidal_forcing_params,
             use_dask=use_dask,
-            bypass_validation=bypass_validation,
         )
 
     def _correct_tides(self, data):

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -936,7 +936,6 @@ def _to_yaml(forcing_object, filepath: Union[str, Path]) -> None:
             "child_grid",
             "ds",
             "use_dask",
-            "bypass_validation",
             "climatology",
         )
     ]

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -116,6 +116,22 @@ def test_initial_conditions_missing_bgc_path(example_grid, use_dask):
         )
 
 
+# Test initialization with missing ini_time
+def test_initial_conditions_missing_ini_time(example_grid, use_dask):
+
+    fname = Path(download_test_data("GLORYS_coarse_test_data.nc"))
+    with pytest.raises(
+        ValueError,
+        match="`ini_time` must be a valid datetime object and cannot be None.",
+    ):
+        InitialConditions(
+            grid=example_grid,
+            ini_time=None,
+            source={"name": "GLORYS", "path": fname},
+            use_dask=use_dask,
+        )
+
+
 # Test default climatology value
 def test_initial_conditions_default_climatology(example_grid, use_dask):
 


### PR DESCRIPTION
This PR addresses two issues:
* #239 
* #231 

To fix #239, the following changes are made:
* `BoundaryForcing` and `SurfaceForcing` can still receive `start_time = None` and `end_time = None`, however a warning is triggered in that case. This option is now also documented in the docstrings
* `InitialConditions` cannot receive `ini_time = None`, an error will be raised in that case

To fix #231, the `bypass_validation` parameter is now written to YAML and read from YAML.

- [x] Closes #239, closes #231
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
- [x] New functions/methods are listed in `docs/api.rst`