### PR TITLE
Move conversion to float64 to after choosing subdomain

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -18,6 +18,7 @@
 * Enforce double precision on source data to ensure reproducible results ([#244](https://github.com/CWorthy-ocean/roms-tools/pull/244))
 * Results produced with vs. without Dask in test suite now pass with `xr.testing.assert_equal` confirming reproducibility ([#244](https://github.com/CWorthy-ocean/roms-tools/pull/244))
 * Document the option for `start_time = None` and `end_time = None` in the docstrings for `BoundaryForcing` and `SurfaceForcing`, specifying that when both are `None`, no time filtering is applied to the data. Also, ensure a warning is raised in this case to inform the user. ([#249](https://github.com/CWorthy-ocean/roms-tools/pull/249))
+* Move conversion to double precision to after choosing subdomain of source data, ensuring a speed-up in grid generation and other forcing datasets that do not use Dask ([#264](https://github.com/CWorthy-ocean/roms-tools/pull/264))
 
 ### Documentation
 

--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -131,10 +131,13 @@ class BoundaryForcing:
         data = self._get_data()
 
         if self.apply_2d_horizontal_fill:
+
             data.choose_subdomain(
                 target_coords,
                 buffer_points=20,  # lateral fill needs good buffer from data margin
             )
+            # Enforce double precision to ensure reproducibility
+            data.convert_to_float64()
             data.extrapolate_deepest_to_bottom()
             data.apply_lateral_fill()
 
@@ -162,6 +165,8 @@ class BoundaryForcing:
                 )
 
                 if not self.apply_2d_horizontal_fill:
+                    # Enforce double precision to ensure reproducibility
+                    bdry_data.convert_to_float64()
                     bdry_data.extrapolate_deepest_to_bottom()
 
                 processed_fields = {}

--- a/roms_tools/setup/datasets.py
+++ b/roms_tools/setup/datasets.py
@@ -129,9 +129,6 @@ class Dataset:
             # Make sure that depth is ascending
             ds = self.ensure_dimension_is_ascending(ds, dim="depth")
 
-        # Enforce double precision to ensure reproducibility
-        ds = convert_to_float64(ds)
-
         self.infer_horizontal_resolution(ds)
 
         # Check whether the data covers the entire globe
@@ -513,6 +510,25 @@ class Dataset:
             This method does not return any value. Subclasses are expected to modify the dataset in-place.
         """
         pass
+
+    def convert_to_float64(self) -> None:
+        """Convert all data variables in the dataset to float64.
+
+        This method updates the dataset by converting all of its data variables to the
+        `float64` data type, ensuring consistency for numerical operations that require
+        high precision. The dataset is modified in place.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+            This method modifies the dataset in place and does not return anything.
+        """
+        ds = self.ds.astype({var: "float64" for var in self.ds.data_vars})
+        object.__setattr__(self, "ds", ds)
 
     def choose_subdomain(
         self,
@@ -2242,19 +2258,3 @@ def decode_string(byte_array):
     )
 
     return decoded_string
-
-
-def convert_to_float64(ds: xr.Dataset) -> xr.Dataset:
-    """Convert all data variables in an xarray.Dataset to float64.
-
-    Parameters
-    ----------
-    ds : xr.Dataset
-        Input dataset.
-
-    Returns
-    -------
-    xr.Dataset
-        Dataset with all data variables converted to float64.
-    """
-    return ds.astype({var: "float64" for var in ds.data_vars})

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -150,6 +150,8 @@ class InitialConditions:
             target_coords,
             buffer_points=20,  # lateral fill needs good buffer from data margin
         )
+        # Enforce double precision to ensure reproducibility
+        data.convert_to_float64()
         data.extrapolate_deepest_to_bottom()
         data.apply_lateral_fill()
 

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -130,6 +130,8 @@ class SurfaceForcing:
             target_coords,
             buffer_points=20,  # lateral fill needs some buffer from data margin
         )
+        # Enforce double precision to ensure reproducibility
+        data.convert_to_float64()
 
         data.apply_lateral_fill()
 

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -84,6 +84,9 @@ class TidalForcing:
             target_coords,
             buffer_points=20,
         )
+        # Enforce double precision to ensure reproducibility
+        data.convert_to_float64()
+
         # select desired number of constituents
         object.__setattr__(data, "ds", data.ds.isel(ntides=slice(None, self.ntides)))
         self._correct_tides(data)

--- a/roms_tools/setup/topography.py
+++ b/roms_tools/setup/topography.py
@@ -145,6 +145,8 @@ def _make_raw_topography(
         The regridded topography data with the sign flipped (bathymetry positive).
     """
     data.choose_subdomain(target_coords, buffer_points=3, verbose=verbose)
+    # Enforce double precision to ensure reproducibility
+    data.convert_to_float64()
 
     if verbose:
         start_time = time.time()


### PR DESCRIPTION
### Issue
#244 enforced double precision on the source data to ensure reproducibility. However, this led to significant slowdowns when Dask was not used. For example, the example grid in the documentation now takes 2 minutes to generate instead of 7 seconds. This issue arose because the conversion to double precision was applied to the entire source dataset, even when only a subset of the data (in both spatial and temporal dimensions) was needed downstream.

### Solution
This pull request moves the conversion to double precision to occur only after selecting the relevant subdomain from the data. As a result, grid generation—and likely all other non-Dask operations—are now much faster again.

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
