### PR TITLE
Unfreeze arguments in all data classes

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,8 @@
 
 ### Internal Changes
 
+* Unfreeze arguments in all dataclasses ([#276](https://github.com/CWorthy-ocean/roms-tools/pull/276))
+
 ### Documentation
 
 ### Bugfixes

--- a/roms_tools/analysis/roms_output.py
+++ b/roms_tools/analysis/roms_output.py
@@ -15,7 +15,7 @@ from roms_tools.vertical_coordinate import (
 )
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class ROMSOutput:
     """Represents ROMS model output.
 
@@ -49,10 +49,10 @@ class ROMSOutput:
         self._check_vertical_coordinate(ds)
         ds = self._add_absolute_time(ds)
         ds = self._add_lat_lon_coords(ds)
-        object.__setattr__(self, "ds", ds)
+        self.ds = ds
 
         # Dataset for depth coordinates
-        object.__setattr__(self, "ds_depth_coords", xr.Dataset())
+        self.ds_depth_coords = xr.Dataset()
 
     def plot(
         self,
@@ -435,7 +435,7 @@ class ROMSOutput:
                         )
                 else:
                     # Set the model reference date if not already set
-                    object.__setattr__(self, "model_reference_date", inferred_date)
+                    self.model_reference_date = inferred_date
             else:
                 # Handle case where no match is found
                 if hasattr(self, "model_reference_date") and self.model_reference_date:

--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -35,7 +35,7 @@ from roms_tools.setup.utils import (
 )
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class BoundaryForcing:
     """Represents boundary forcing input data for ROMS.
 
@@ -124,7 +124,7 @@ class BoundaryForcing:
 
         self._input_checks()
         # Dataset for depth coordinates
-        object.__setattr__(self, "ds_depth_coords", xr.Dataset())
+        self.ds_depth_coords = xr.Dataset()
 
         target_coords = get_target_coords(self.grid)
 
@@ -335,7 +335,7 @@ class BoundaryForcing:
         for var_name in ds.data_vars:
             ds[var_name] = substitute_nans_by_fillvalue(ds[var_name])
 
-        object.__setattr__(self, "ds", ds)
+        self.ds = ds
 
     def _input_checks(self):
         # Check that start_time and end_time are both None or none of them is
@@ -361,11 +361,10 @@ class BoundaryForcing:
             raise ValueError("`source` must include a 'path'.")
 
         # Set 'climatology' to False if not provided in 'source'
-        object.__setattr__(
-            self,
-            "source",
-            {**self.source, "climatology": self.source.get("climatology", False)},
-        )
+        self.source = {
+            **self.source,
+            "climatology": self.source.get("climatology", False),
+        }
 
         # Ensure adjust_depth_for_sea_surface_height is only used with type="physics"
         if self.type == "bgc" and self.adjust_depth_for_sea_surface_height:
@@ -373,7 +372,7 @@ class BoundaryForcing:
                 "adjust_depth_for_sea_surface_height is not applicable for BGC fields. "
                 "Setting it to False."
             )
-            object.__setattr__(self, "adjust_depth_for_sea_surface_height", False)
+            self.adjust_depth_for_sea_surface_height = False
         elif self.adjust_depth_for_sea_surface_height:
             logging.info("Sea surface height will be used to adjust depth coordinates.")
         else:
@@ -495,7 +494,7 @@ class BoundaryForcing:
                 else:
                     variable_info[var_name] = {**default_info, "validate": False}
 
-        object.__setattr__(self, "variable_info", variable_info)
+        self.variable_info = variable_info
 
     def _write_into_dataset(self, direction, processed_fields, ds=None):
         if ds is None:
@@ -563,7 +562,7 @@ class BoundaryForcing:
 
         bdry_coords = get_boundary_coords()
 
-        object.__setattr__(self, "bdry_coords", bdry_coords)
+        self.bdry_coords = bdry_coords
 
     def _get_depth_coordinates(
         self,

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -24,7 +24,7 @@ from roms_tools.setup.utils import extract_single_value
 from pathlib import Path
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class Grid:
     """A single ROMS grid, used for creating, plotting, and then saving a new ROMS
     domain grid.
@@ -131,7 +131,7 @@ class Grid:
 
     def _input_checks(self):
         if self.topography_source is None:
-            object.__setattr__(self, "topography_source", {"name": "ETOPO5"})
+            self.topography_source = {"name": "ETOPO5"}
 
         if "name" not in self.topography_source:
             raise ValueError(
@@ -157,7 +157,7 @@ class Grid:
                 "========================================================================================================"
             )
 
-        object.__setattr__(self, "ds", ds)
+        self.ds = ds
 
     def update_topography(
         self, topography_source=None, hmin=None, verbose=False
@@ -223,9 +223,9 @@ class Grid:
             )
 
         # Update the grid's dataset and related attributes
-        object.__setattr__(self, "ds", ds)
-        object.__setattr__(self, "topography_source", topography_source)
-        object.__setattr__(self, "hmin", hmin)
+        self.ds = ds
+        self.topography_source = topography_source
+        self.hmin = hmin
 
     def update_vertical_coordinate(
         self, N=None, theta_s=None, theta_b=None, hc=None, verbose=False
@@ -321,11 +321,11 @@ class Grid:
                 "========================================================================================================"
             )
 
-        object.__setattr__(self, "ds", ds)
-        object.__setattr__(self, "theta_s", theta_s)
-        object.__setattr__(self, "theta_b", theta_b)
-        object.__setattr__(self, "hc", hc)
-        object.__setattr__(self, "N", N)
+        self.ds = ds
+        self.theta_s = theta_s
+        self.theta_b = theta_b
+        self.hc = hc
+        self.N = N
 
     def _straddle(self) -> None:
         """Check if the Greenwich meridian goes through the domain.
@@ -342,9 +342,9 @@ class Grid:
             np.abs(self.ds.lon_rho.diff("xi_rho")).max() > 300
             or np.abs(self.ds.lon_rho.diff("eta_rho")).max() > 300
         ):
-            object.__setattr__(self, "straddle", True)
+            self.straddle = True
         else:
-            object.__setattr__(self, "straddle", False)
+            self.straddle = False
 
     def _coarsen(self):
         """Update the grid by adding grid variables that are coarsened versions of the
@@ -391,7 +391,7 @@ class Grid:
             ds[coarse_var].attrs["long_name"] = f"{long_name} on coarsened grid"
             ds[coarse_var].attrs["units"] = ds[fine_var].attrs["units"]
 
-        object.__setattr__(self, "ds", ds)
+        self.ds = ds
 
     def plot(
         self, bathymetry: bool = True, title: str = None, with_dim_names: bool = False
@@ -581,14 +581,14 @@ class Grid:
         grid = cls.__new__(cls)
 
         # Set the dataset for the grid instance
-        object.__setattr__(grid, "ds", ds)
+        grid.ds = ds
 
         # Check if the Greenwich meridian goes through the domain.
         grid._straddle()
 
         if not all(coord in grid.ds for coord in ["lat_u", "lon_u", "lat_v", "lon_v"]):
             ds = _add_lat_lon_at_velocity_points(grid.ds, grid.straddle)
-            object.__setattr__(grid, "ds", ds)
+            grid.ds = ds
 
         # Coarsen the grid if necessary
         if not all(
@@ -606,7 +606,7 @@ class Grid:
         for var in ["lat_rho", "lon_rho", "lat_coarse", "lon_coarse"]:
             if var not in ds.coords:
                 ds = grid.ds.set_coords(var)
-                object.__setattr__(grid, "ds", ds)
+                grid.ds = ds
 
         # Update vertical coordinate if necessary
         if not all(var in grid.ds for var in ["Cs_r", "Cs_w"]):
@@ -620,14 +620,14 @@ class Grid:
                 N=N, theta_s=theta_s, theta_b=theta_b, hc=hc, verbose=True
             )
         else:
-            object.__setattr__(grid, "theta_s", ds.attrs["theta_s"].item())
-            object.__setattr__(grid, "theta_b", ds.attrs["theta_b"].item())
-            object.__setattr__(grid, "hc", ds.attrs["hc"].item())
-            object.__setattr__(grid, "N", len(ds.s_rho))
+            grid.theta_s = ds.attrs["theta_s"].item()
+            grid.theta_b = ds.attrs["theta_b"].item()
+            grid.hc = ds.attrs["hc"].item()
+            grid.N = len(ds.s_rho)
 
         # Manually set the remaining attributes by extracting parameters from dataset
-        object.__setattr__(grid, "nx", ds.sizes["xi_rho"] - 2)
-        object.__setattr__(grid, "ny", ds.sizes["eta_rho"] - 2)
+        grid.nx = ds.sizes["xi_rho"] - 2
+        grid.ny = ds.sizes["eta_rho"] - 2
         if "center_lon" in ds.attrs:
             center_lon = ds.attrs["center_lon"]
         elif "tra_lon" in ds:
@@ -637,7 +637,7 @@ class Grid:
                 "Missing grid information: 'center_lon' attribute or 'tra_lon' variable "
                 "must be present in the dataset."
             )
-        object.__setattr__(grid, "center_lon", center_lon)
+        grid.center_lon = center_lon
         if "center_lat" in ds.attrs:
             center_lat = ds.attrs["center_lat"]
         elif "tra_lat" in ds:
@@ -647,7 +647,7 @@ class Grid:
                 "Missing grid information: 'center_lat' attribute or 'tra_lat' variable "
                 "must be present in the dataset."
             )
-        object.__setattr__(grid, "center_lat", center_lat)
+        grid.center_lat = center_lat
         if "rot" in ds.attrs:
             rot = ds.attrs["rot"]
         elif "rotate" in ds:
@@ -657,7 +657,7 @@ class Grid:
                 "Missing grid information: 'rot' attribute or 'rotate' variable "
                 "must be present in the dataset."
             )
-        object.__setattr__(grid, "rot", rot)
+        grid.rot = rot
 
         for attr in [
             "size_x",
@@ -848,7 +848,7 @@ class Grid:
                 "========================================================================================================"
             )
 
-        object.__setattr__(self, "ds", ds)
+        self.ds = ds
 
     def _add_global_metadata(self, ds):
         """Add global metadata and attributes to the dataset.

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -34,7 +34,7 @@ from roms_tools.setup.utils import (
 )
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class InitialConditions:
     """Represents initial conditions for ROMS, including physical and biogeochemical
     data.
@@ -115,7 +115,7 @@ class InitialConditions:
 
         self._input_checks()
         # Dataset for depth coordinates
-        object.__setattr__(self, "ds_depth_coords", xr.Dataset())
+        self.ds_depth_coords = xr.Dataset()
 
         processed_fields = {}
         processed_fields = self._process_data(processed_fields, type="physics")
@@ -135,7 +135,7 @@ class InitialConditions:
         for var_name in ds.data_vars:
             ds[var_name] = substitute_nans_by_fillvalue(ds[var_name])
 
-        object.__setattr__(self, "ds", ds)
+        self.ds = ds
 
     def _process_data(self, processed_fields, type="physics"):
 
@@ -247,14 +247,10 @@ class InitialConditions:
         if "path" not in self.source.keys():
             raise ValueError("`source` must include a 'path'.")
         # set self.source["climatology"] to False if not provided
-        object.__setattr__(
-            self,
-            "source",
-            {
-                **self.source,
-                "climatology": self.source.get("climatology", False),
-            },
-        )
+        self.source = {
+            **self.source,
+            "climatology": self.source.get("climatology", False),
+        }
         if self.bgc_source is not None:
             if "name" not in self.bgc_source.keys():
                 raise ValueError(
@@ -265,14 +261,10 @@ class InitialConditions:
                     "`bgc_source` must include a 'path' if it is provided."
                 )
             # set self.bgc_source["climatology"] to False if not provided
-            object.__setattr__(
-                self,
-                "bgc_source",
-                {
-                    **self.bgc_source,
-                    "climatology": self.bgc_source.get("climatology", False),
-                },
-            )
+            self.bgc_source = {
+                **self.bgc_source,
+                "climatology": self.bgc_source.get("climatology", False),
+            }
         if self.adjust_depth_for_sea_surface_height:
             logging.info("Sea surface height will be used to adjust depth coordinates.")
         else:

--- a/roms_tools/setup/nesting.py
+++ b/roms_tools/setup/nesting.py
@@ -20,7 +20,7 @@ from roms_tools.setup.utils import (
 )
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class ChildGrid(Grid):
     """Represents a ROMS child grid that is compatible with the provided parent grid.
 
@@ -87,7 +87,7 @@ class ChildGrid(Grid):
             self.metadata["period"],
         )
 
-        object.__setattr__(self, "ds_nesting", ds_nesting)
+        self.ds_nesting = ds_nesting
 
     def _modify_child_topography_and_mask(self):
         """Adjust the child grid's topography and mask to align with the parent grid.
@@ -107,7 +107,7 @@ class ChildGrid(Grid):
             parent_grid_ds, child_grid_ds
         )
 
-        object.__setattr__(self, "ds", child_grid_ds)
+        self.ds = child_grid_ds
 
     def update_topography(
         self, topography_source=None, hmin=None, verbose=False

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -30,7 +30,7 @@ from roms_tools.setup.utils import (
 )
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class SurfaceForcing:
     """Represents surface forcing input data for ROMS.
 
@@ -121,10 +121,10 @@ class SurfaceForcing:
             logging.info("Data will be interpolated onto grid coarsened by factor 2.")
         else:
             logging.info("Data will be interpolated onto fine grid.")
-        object.__setattr__(self, "use_coarse_grid", use_coarse_grid)
+        self.use_coarse_grid = use_coarse_grid
 
         target_coords = get_target_coords(self.grid, self.use_coarse_grid)
-        object.__setattr__(self, "target_coords", target_coords)
+        self.target_coords = target_coords
 
         data.choose_subdomain(
             target_coords,
@@ -171,7 +171,7 @@ class SurfaceForcing:
         for var_name in ds.data_vars:
             ds[var_name] = substitute_nans_by_fillvalue(ds[var_name])
 
-        object.__setattr__(self, "ds", ds)
+        self.ds = ds
 
     def _input_checks(self):
         # Check that start_time and end_time are both None or none of them is
@@ -197,11 +197,10 @@ class SurfaceForcing:
             raise ValueError("`source` must include a 'path'.")
 
         # Set 'climatology' to False if not provided in 'source'
-        object.__setattr__(
-            self,
-            "source",
-            {**self.source, "climatology": self.source.get("climatology", False)},
-        )
+        self.source = {
+            **self.source,
+            "climatology": self.source.get("climatology", False),
+        }
 
         # Validate 'coarse_grid_mode'
         valid_modes = ["auto", "always", "never"]
@@ -339,7 +338,7 @@ class SurfaceForcing:
                 else:
                     variable_info[var_name] = {**default_info, "validate": False}
 
-        object.__setattr__(self, "variable_info", variable_info)
+        self.variable_info = variable_info
 
     def _apply_correction(self, processed_fields, data):
 

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -25,7 +25,7 @@ from roms_tools.setup.utils import (
 )
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class TidalForcing:
     """Represents tidal forcing for ROMS.
 
@@ -88,7 +88,7 @@ class TidalForcing:
         data.convert_to_float64()
 
         # select desired number of constituents
-        object.__setattr__(data, "ds", data.ds.isel(ntides=slice(None, self.ntides)))
+        data.ds = data.ds.isel(ntides=slice(None, self.ntides))
         self._correct_tides(data)
 
         data.apply_lateral_fill()
@@ -144,7 +144,7 @@ class TidalForcing:
         for var_name in ds.data_vars:
             ds[var_name] = substitute_nans_by_fillvalue(ds[var_name])
 
-        object.__setattr__(self, "ds", ds)
+        self.ds = ds
 
     def _input_checks(self):
 
@@ -218,7 +218,7 @@ class TidalForcing:
             },
         }
 
-        object.__setattr__(self, "variable_info", variable_info)
+        self.variable_info = variable_info
 
     def _write_into_dataset(self, processed_fields, d_meta):
 
@@ -504,7 +504,7 @@ class TidalForcing:
         var_names.pop("sal_Re", None)  # Remove "sal_Re" if it exists
         var_names.pop("sal_Im", None)  # Remove "sal_Im" if it exists
 
-        object.__setattr__(data, "var_names", var_names)
+        data.var_names = var_names
 
 
 def modified_julian_days(year, month, day, hour=0):


### PR DESCRIPTION
This PR unfreezes (thaws?) the arguments in all data classes, so that we can avoid the ugly
```
object.__setattr__(self, "ds", ds)
```
and simply do
```
self.ds = ds
```
cc @ScottEilerman 

- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`