### PR TITLE
Update pypi package action, add test upload action

### DIFF
--- a/.github/workflows/pypipublish.yaml
+++ b/.github/workflows/pypipublish.yaml
@@ -65,6 +65,27 @@ jobs:
           python -m pip install dist/roms_tools*.whl
           python -c "import roms_tools; print(roms_tools.__version__)"
 
+  upload-to-test-pypi:
+    needs: test-built-dist
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/roms-tools
+
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: releases
+          path: dist
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
   upload-to-pypi:
     needs: test-built-dist
     if: github.event_name == 'release'
@@ -78,6 +99,6 @@ jobs:
           name: releases
           path: dist
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           repository-url: https://upload.pypi.org/legacy/


### PR DESCRIPTION
This PR contains the following changes:

1. Fix an issue with publishing to PyPi using an old version of the Github `pypa/gh-action-pypi-publish` action.
2. Add a Github action for uploading tagged commits to test pypi

- [x] Passes `pre-commit run --all-files`

