### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/ci/environment-with-xesmf.yml
+++ b/ci/environment-with-xesmf.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.10
+  - python>=3.11
   - xesmf
   # testing
   - zarr

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.10
+  - python>=3.11
   # testing
   - zarr
   - pytest

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+* Drop support for Python 3.10 ([#309](https://github.com/CWorthy-ocean/roms-tools/pull/309))
+
 ### Internal Changes
 
 * Introduce Pydantic `Release` object refactoring the `CDRVolumePointSource` ([#298](https://github.com/CWorthy-ocean/roms-tools/pull/298))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,11 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "xarray >=2022.6.0",
     "numpy",


### PR DESCRIPTION
Motivation for this decision is [this comment](https://github.com/CWorthy-ocean/roms-tools/pull/301#issuecomment-2899118739).

- [ ] Changes are documented in `docs/releases.md`
