### PR TITLE
Allow bigger grids up to 25000km

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+* Allow bigger grid sizes of up to 25000 km ([#311](https://github.com/CWorthy-ocean/roms-tools/pull/311))
+
 ### Breaking Changes
 
 * Drop support for Python 3.10 ([#309](https://github.com/CWorthy-ocean/roms-tools/pull/309))

--- a/roms_tools/constants.py
+++ b/roms_tools/constants.py
@@ -1,3 +1,3 @@
 R_EARTH = 6371315.0  # Earth radius in meters
-MAXIMUM_GRID_SIZE = 20000  # in km
+MAXIMUM_GRID_SIZE = 25000  # in km
 NUM_TRACERS = 34  # Number of tracers (temperature, salinity, BGC tracers)

--- a/roms_tools/constants.py
+++ b/roms_tools/constants.py
@@ -1,2 +1,3 @@
 R_EARTH = 6371315.0  # Earth radius in meters
+MAXIMUM_GRID_SIZE = 20000  # in km
 NUM_TRACERS = 34  # Number of tracers (temperature, salinity, BGC tracers)

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import yaml
 import importlib.metadata
 from typing import Dict, Union, List
-from roms_tools.constants import R_EARTH
+from roms_tools.constants import R_EARTH, MAXIMUM_GRID_SIZE
 from roms_tools.utils import save_datasets
 from roms_tools.setup.topography import _add_topography
 from roms_tools.setup.mask import _add_mask, _add_velocity_masks
@@ -894,13 +894,12 @@ class Grid:
     def _raise_if_domain_size_too_large(self):
         """Raise a ValueError if the domain size exceeds the allowable threshold.
 
-        Checks if either the x or y domain size exceeds 20,000 km and raises an error
-        with appropriate details if the threshold is surpassed.
+        Checks if either the x or y domain size exceeds the threshold and raises an
+        error with appropriate details if the threshold is surpassed.
         """
-        threshold = 20000
-        if self.size_x > threshold or self.size_y > threshold:
+        if self.size_x > MAXIMUM_GRID_SIZE or self.size_y > MAXIMUM_GRID_SIZE:
             raise ValueError(
-                f"Domain size exceeds the allowable limit of {threshold} km. "
+                f"Domain size exceeds the allowable limit of {MAXIMUM_GRID_SIZE} km. "
                 f"Received dimensions: size_x = {self.size_x} km, size_y = {self.size_y} km. "
                 "Please reduce the domain size to meet the threshold."
             )

--- a/roms_tools/tests/test_setup/test_grid.py
+++ b/roms_tools/tests/test_setup/test_grid.py
@@ -6,6 +6,7 @@ import importlib.metadata
 import textwrap
 from roms_tools.download import download_test_data
 from conftest import calculate_file_hash
+from roms_tools.constants import MAXIMUM_GRID_SIZE
 from pathlib import Path
 
 
@@ -102,7 +103,23 @@ def test_plot_save_methods(tmp_path):
 
 def test_raise_if_domain_too_large():
     with pytest.raises(ValueError, match="Domain size exceeds"):
-        Grid(nx=3, ny=3, size_x=30000, size_y=30000, center_lon=0, center_lat=51.5)
+        Grid(
+            nx=3,
+            ny=3,
+            size_x=MAXIMUM_GRID_SIZE + 10,
+            size_y=1000,
+            center_lon=0,
+            center_lat=51.5,
+        )
+    with pytest.raises(ValueError, match="Domain size exceeds"):
+        Grid(
+            nx=3,
+            ny=3,
+            size_x=1000,
+            size_y=MAXIMUM_GRID_SIZE + 10,
+            center_lon=0,
+            center_lat=51.5,
+        )
 
     # test grid with reasonable domain size
     grid = Grid(


### PR DESCRIPTION
This PR bumps up the allowable grid size to 25000km as discussed in #310. It also introduces a global constant `MAXIMUM_GRID_SIZE`, so that we can easily change the number in the future. 

- [x] Closes #310
- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`


### Thoughts about future PRs

Our plotting methods become worse for very large grids, that's why we limit their size. In a future PR, we may want to change the projections for very large grids. The Pacific domain looks okay with the current plotting method (it has a width of 23000km), but there may be room for improvement:

<img width="755" alt="Image" src="https://github.com/user-attachments/assets/78e8fd1d-4c70-4a13-a674-eaa774471ae1" />