### PR TITLE
Enable and run isort

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,26 +1,28 @@
-import pytest
+import hashlib
 from datetime import datetime
+from pathlib import Path
+
+import h5py
+import pytest
+
 from roms_tools import (
-    Grid,
-    TidalForcing,
-    InitialConditions,
     BoundaryForcing,
-    SurfaceForcing,
+    Grid,
+    InitialConditions,
     RiverForcing,
+    SurfaceForcing,
+    TidalForcing,
 )
+from roms_tools.download import download_test_data
 from roms_tools.setup.datasets import (
-    TPXODataset,
-    GLORYSDataset,
-    ERA5Dataset,
     CESMBGCDataset,
     CESMBGCSurfaceForcingDataset,
+    ERA5Dataset,
+    GLORYSDataset,
+    TPXODataset,
     UnifiedBGCDataset,
     UnifiedBGCSurfaceDataset,
 )
-from roms_tools.download import download_test_data
-import hashlib
-import h5py
-from pathlib import Path
 
 
 def pytest_addoption(parser):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,12 +67,8 @@ exclude = ["docs", "tests", "tests.*", "docs.*"]
 [tool.setuptools.package-data]
 roms_tools = ["py.typed"]
 
-[tool.isort]
-profile = "black"
-skip_gitignore = true
-float_to_top = true
-default_section = "THIRDPARTY"
-known_first_party = "roms_tools"
+[tool.ruff.lint]
+extend-select = ["I"]
 
 [mypy]
 files = "roms_tools/**/*.py"

--- a/roms_tools/__init__.py
+++ b/roms_tools/__init__.py
@@ -1,5 +1,5 @@
-from importlib.metadata import version as _version
 import logging  # noqa: F811
+from importlib.metadata import version as _version
 
 try:
     __version__ = _version("roms_tools")
@@ -8,17 +8,17 @@ except ImportError:  # pragma: no cover
     __version__ = "9999"
 
 
-from roms_tools.setup.grid import Grid  # noqa: F401
-from roms_tools.setup.tides import TidalForcing  # noqa: F401
-from roms_tools.setup.surface_forcing import SurfaceForcing  # noqa: F401
-from roms_tools.setup.initial_conditions import InitialConditions  # noqa: F401
-from roms_tools.setup.boundary_forcing import BoundaryForcing  # noqa: F401
-from roms_tools.setup.river_forcing import RiverForcing  # noqa: F401
-from roms_tools.setup.cdr_release import VolumeRelease, TracerPerturbation  # noqa: F401
-from roms_tools.setup.cdr_forcing import CDRForcing  # noqa: F401
-from roms_tools.setup.nesting import ChildGrid  # noqa: F401
-from roms_tools.tiling.partition import partition_netcdf  # noqa: F401
 from roms_tools.analysis.roms_output import ROMSOutput  # noqa: F401
+from roms_tools.setup.boundary_forcing import BoundaryForcing  # noqa: F401
+from roms_tools.setup.cdr_forcing import CDRForcing  # noqa: F401
+from roms_tools.setup.cdr_release import TracerPerturbation, VolumeRelease  # noqa: F401
+from roms_tools.setup.grid import Grid  # noqa: F401
+from roms_tools.setup.initial_conditions import InitialConditions  # noqa: F401
+from roms_tools.setup.nesting import ChildGrid  # noqa: F401
+from roms_tools.setup.river_forcing import RiverForcing  # noqa: F401
+from roms_tools.setup.surface_forcing import SurfaceForcing  # noqa: F401
+from roms_tools.setup.tides import TidalForcing  # noqa: F401
+from roms_tools.tiling.partition import partition_netcdf  # noqa: F401
 
 # Configure logging when the package is imported
 logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")

--- a/roms_tools/analysis/roms_output.py
+++ b/roms_tools/analysis/roms_output.py
@@ -1,27 +1,29 @@
-import xarray as xr
-import numpy as np
-import matplotlib.pyplot as plt
-from roms_tools.plot import _plot, _section_plot, _profile_plot, _line_plot
-from roms_tools.regrid import LateralRegridFromROMS, VerticalRegridFromROMS
-from dataclasses import dataclass, field
-from typing import Union, Optional
-from pathlib import Path
-import re
 import logging
+import re
 import warnings
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
 from roms_tools import Grid
+from roms_tools.analysis.utils import _validate_plot_inputs
+from roms_tools.plot import _line_plot, _plot, _profile_plot, _section_plot
+from roms_tools.regrid import LateralRegridFromROMS, VerticalRegridFromROMS
+from roms_tools.utils import (
+    _generate_coordinate_range,
+    _load_data,
+    _remove_edge_nans,
+    interpolate_from_rho_to_u,
+    interpolate_from_rho_to_v,
+)
 from roms_tools.vertical_coordinate import (
     compute_depth_coordinates,
 )
-from roms_tools.utils import (
-    _load_data,
-    interpolate_from_rho_to_u,
-    interpolate_from_rho_to_v,
-    _generate_coordinate_range,
-    _remove_edge_nans,
-)
-from roms_tools.analysis.utils import _validate_plot_inputs
 
 
 @dataclass(kw_only=True)

--- a/roms_tools/plot.py
+++ b/roms_tools/plot.py
@@ -1,7 +1,7 @@
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
-import xarray as xr
 import numpy as np
+import xarray as xr
 
 
 def _plot(

--- a/roms_tools/regrid.py
+++ b/roms_tools/regrid.py
@@ -1,6 +1,7 @@
-import xgcm
-import xarray as xr
 import warnings
+
+import xarray as xr
+import xgcm
 
 
 class LateralRegridToROMS:

--- a/roms_tools/setup/boundary_forcing.py
+++ b/roms_tools/setup/boundary_forcing.py
@@ -1,40 +1,42 @@
-import xarray as xr
-import numpy as np
-from scipy.ndimage import label
-import logging
 import importlib.metadata
-from typing import Dict, Union, List, Optional
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-import matplotlib.pyplot as plt
 from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from scipy.ndimage import label
+
 from roms_tools import Grid
+from roms_tools.plot import _line_plot, _section_plot
 from roms_tools.regrid import LateralRegridToROMS, VerticalRegridToROMS
-from roms_tools.utils import save_datasets
-from roms_tools.vertical_coordinate import compute_depth
-from roms_tools.plot import _section_plot, _line_plot
+from roms_tools.setup.datasets import CESMBGCDataset, GLORYSDataset, UnifiedBGCDataset
+from roms_tools.setup.utils import (
+    _from_yaml,
+    _to_dict,
+    _write_to_yaml,
+    add_time_info_to_ds,
+    compute_barotropic_velocity,
+    compute_missing_bgc_variables,
+    get_boundary_coords,
+    get_target_coords,
+    get_variable_metadata,
+    group_dataset,
+    nan_check,
+    one_dim_fill,
+    rotate_velocities,
+    substitute_nans_by_fillvalue,
+)
 from roms_tools.utils import (
     interpolate_from_rho_to_u,
     interpolate_from_rho_to_v,
+    save_datasets,
     transpose_dimensions,
 )
-from roms_tools.setup.datasets import GLORYSDataset, CESMBGCDataset, UnifiedBGCDataset
-from roms_tools.setup.utils import (
-    get_variable_metadata,
-    group_dataset,
-    get_target_coords,
-    rotate_velocities,
-    compute_barotropic_velocity,
-    compute_missing_bgc_variables,
-    one_dim_fill,
-    nan_check,
-    substitute_nans_by_fillvalue,
-    add_time_info_to_ds,
-    get_boundary_coords,
-    _to_dict,
-    _write_to_yaml,
-    _from_yaml,
-)
+from roms_tools.vertical_coordinate import compute_depth
 
 
 @dataclass(kw_only=True)

--- a/roms_tools/setup/cdr_forcing.py
+++ b/roms_tools/setup/cdr_forcing.py
@@ -1,43 +1,45 @@
+import itertools
+import logging
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Iterator
-from pydantic import (
-    BaseModel,
-    model_validator,
-    Field,
-    model_serializer,
-    RootModel,
-    conlist,
-)
+
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
-import cartopy.crs as ccrs
-import logging
-import itertools
-from collections import Counter
-import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
+from pydantic import (
+    BaseModel,
+    Field,
+    RootModel,
+    conlist,
+    model_serializer,
+    model_validator,
+)
+
 from roms_tools import Grid
-from roms_tools.plot import _plot, _get_projection
+from roms_tools.plot import _get_projection, _plot
 from roms_tools.regrid import LateralRegridFromROMS
+from roms_tools.setup.cdr_release import (
+    Release,
+    ReleaseType,
+    TracerPerturbation,
+    VolumeRelease,
+)
+from roms_tools.setup.utils import (
+    _from_yaml,
+    _to_dict,
+    _write_to_yaml,
+    add_tracer_metadata_to_ds,
+    convert_to_relative_days,
+    gc_dist,
+)
 from roms_tools.utils import (
     _generate_coordinate_range,
     _remove_edge_nans,
     save_datasets,
-)
-from roms_tools.setup.utils import (
-    convert_to_relative_days,
-    gc_dist,
-    add_tracer_metadata_to_ds,
-    _to_dict,
-    _write_to_yaml,
-    _from_yaml,
-)
-from roms_tools.setup.cdr_release import (
-    Release,
-    VolumeRelease,
-    TracerPerturbation,
-    ReleaseType,
 )
 
 INCLUDE_ALL_RELEASE_NAMES = "all"

--- a/roms_tools/setup/cdr_release.py
+++ b/roms_tools/setup/cdr_release.py
@@ -1,22 +1,22 @@
+import warnings
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from abc import abstractmethod, ABC
+from datetime import datetime
 from enum import StrEnum, auto
-
-from pydantic import (
-    BaseModel,
-    model_validator,
-    Field,
-    ConfigDict,
-    model_serializer,
-    field_validator,
-)
 from typing import Literal
 
+from annotated_types import Ge, Le
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from pydantic_core.core_schema import ValidationInfo
 from typing_extensions import Annotated
-from annotated_types import Ge, Le
-from datetime import datetime
-import warnings
+
 from roms_tools.setup.utils import get_tracer_defaults
 
 NonNegativeFloat = Annotated[float, Ge(0)]

--- a/roms_tools/setup/datasets.py
+++ b/roms_tools/setup/datasets.py
@@ -1,29 +1,31 @@
+import logging
 import time
-import xarray as xr
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-import numpy as np
-from typing import Dict, Optional, Union, List
 from pathlib import Path
-import logging
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+import xarray as xr
+
 from roms_tools.constants import R_EARTH
-from roms_tools.utils import _load_data
-from roms_tools.setup.utils import (
-    assign_dates_to_climatology,
-    interpolate_from_climatology,
-    interpolate_cyclic_time,
-    get_time_type,
-    convert_cftime_to_datetime,
-    one_dim_fill,
-    gc_dist,
-)
 from roms_tools.download import (
     download_correction_data,
-    download_topo,
     download_river_data,
     download_sal_data,
+    download_topo,
 )
 from roms_tools.setup.fill import LateralFill
+from roms_tools.setup.utils import (
+    assign_dates_to_climatology,
+    convert_cftime_to_datetime,
+    gc_dist,
+    get_time_type,
+    interpolate_cyclic_time,
+    interpolate_from_climatology,
+    one_dim_fill,
+)
+from roms_tools.utils import _load_data
 
 # lat-lon datasets
 

--- a/roms_tools/setup/fill.py
+++ b/roms_tools/setup/fill.py
@@ -1,6 +1,6 @@
 import numpy as np
-import xarray as xr
 import pyamg
+import xarray as xr
 from scipy import sparse
 
 

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -1,29 +1,30 @@
-import time
+import importlib.metadata
 import logging
-from dataclasses import dataclass, field, asdict
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, List, Union
 
+import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
-import matplotlib.pyplot as plt
 import yaml
-import importlib.metadata
-from typing import Dict, Union, List
-from roms_tools.constants import R_EARTH, MAXIMUM_GRID_SIZE
-from roms_tools.utils import save_datasets
-from roms_tools.setup.topography import _add_topography
-from roms_tools.setup.mask import _add_mask, _add_velocity_masks
-from roms_tools.vertical_coordinate import compute_depth_coordinates, sigma_stretch
+
+from roms_tools.constants import MAXIMUM_GRID_SIZE, R_EARTH
 from roms_tools.plot import _plot, _section_plot
+from roms_tools.setup.mask import _add_mask, _add_velocity_masks
+from roms_tools.setup.topography import _add_topography
 from roms_tools.setup.utils import (
-    interpolate_from_rho_to_u,
-    interpolate_from_rho_to_v,
-    get_target_coords,
-    gc_dist,
     _pop_grid_data,
     _write_to_yaml,
+    extract_single_value,
+    gc_dist,
+    get_target_coords,
+    interpolate_from_rho_to_u,
+    interpolate_from_rho_to_v,
 )
-from roms_tools.setup.utils import extract_single_value
-from pathlib import Path
+from roms_tools.utils import save_datasets
+from roms_tools.vertical_coordinate import compute_depth_coordinates, sigma_stretch
 
 
 @dataclass(kw_only=True)

--- a/roms_tools/setup/initial_conditions.py
+++ b/roms_tools/setup/initial_conditions.py
@@ -1,38 +1,40 @@
-import xarray as xr
-import numpy as np
 import importlib.metadata
-from dataclasses import dataclass, field
-from typing import Dict, Union, List, Optional
-import matplotlib.pyplot as plt
-from pathlib import Path
 import logging
+from dataclasses import dataclass, field
 from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
 from roms_tools import Grid
+from roms_tools.plot import _line_plot, _plot, _profile_plot, _section_plot
 from roms_tools.regrid import LateralRegridToROMS, VerticalRegridToROMS
-from roms_tools.plot import _plot, _section_plot, _profile_plot, _line_plot
+from roms_tools.setup.datasets import CESMBGCDataset, GLORYSDataset, UnifiedBGCDataset
+from roms_tools.setup.utils import (
+    _from_yaml,
+    _to_dict,
+    _write_to_yaml,
+    compute_barotropic_velocity,
+    compute_missing_bgc_variables,
+    get_target_coords,
+    get_variable_metadata,
+    nan_check,
+    rotate_velocities,
+    substitute_nans_by_fillvalue,
+)
 from roms_tools.utils import (
-    transpose_dimensions,
-    save_datasets,
     get_dask_chunks,
     interpolate_from_rho_to_u,
     interpolate_from_rho_to_v,
+    save_datasets,
+    transpose_dimensions,
 )
 from roms_tools.vertical_coordinate import (
-    compute_depth_coordinates,
     compute_depth,
-)
-from roms_tools.setup.datasets import GLORYSDataset, CESMBGCDataset, UnifiedBGCDataset
-from roms_tools.setup.utils import (
-    nan_check,
-    substitute_nans_by_fillvalue,
-    get_variable_metadata,
-    get_target_coords,
-    rotate_velocities,
-    compute_barotropic_velocity,
-    compute_missing_bgc_variables,
-    _to_dict,
-    _write_to_yaml,
-    _from_yaml,
+    compute_depth_coordinates,
 )
 
 

--- a/roms_tools/setup/mask.py
+++ b/roms_tools/setup/mask.py
@@ -1,12 +1,14 @@
-import xarray as xr
+import warnings
+
 import numpy as np
 import regionmask
-import warnings
+import xarray as xr
 from scipy.ndimage import label
+
 from roms_tools.setup.utils import (
+    handle_boundaries,
     interpolate_from_rho_to_u,
     interpolate_from_rho_to_v,
-    handle_boundaries,
 )
 
 

--- a/roms_tools/setup/nesting.py
+++ b/roms_tools/setup/nesting.py
@@ -1,24 +1,25 @@
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Tuple, Union
+
 import numpy as np
 import xarray as xr
-from scipy.interpolate import griddata
-from dataclasses import dataclass, field
-from typing import Dict, Union, Any, Tuple
-from pathlib import Path
-import logging
-from scipy.interpolate import interp1d
+from scipy.interpolate import griddata, interp1d
+
 from roms_tools import Grid
 from roms_tools.plot import _plot_nesting
-from roms_tools.utils import save_datasets
 from roms_tools.setup.topography import _clip_depth
 from roms_tools.setup.utils import (
-    interpolate_from_rho_to_u,
-    interpolate_from_rho_to_v,
-    get_boundary_coords,
-    wrap_longitudes,
+    _from_yaml,
     _to_dict,
     _write_to_yaml,
-    _from_yaml,
+    get_boundary_coords,
+    interpolate_from_rho_to_u,
+    interpolate_from_rho_to_v,
+    wrap_longitudes,
 )
+from roms_tools.utils import save_datasets
 
 
 @dataclass(kw_only=True)

--- a/roms_tools/setup/river_forcing.py
+++ b/roms_tools/setup/river_forcing.py
@@ -1,29 +1,31 @@
-import xarray as xr
-import numpy as np
 import logging
 from dataclasses import dataclass, field
-import cartopy.crs as ccrs
 from datetime import datetime
-from typing import Dict, Union, List, Optional
 from pathlib import Path
-import matplotlib.pyplot as plt
+from typing import Dict, List, Optional, Union
+
+import cartopy.crs as ccrs
 import matplotlib.cm as cm
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
 from roms_tools import Grid
 from roms_tools.constants import NUM_TRACERS
-from roms_tools.plot import _plot, _get_projection
-from roms_tools.utils import save_datasets
+from roms_tools.plot import _get_projection, _plot
 from roms_tools.setup.datasets import DaiRiverDataset
 from roms_tools.setup.utils import (
-    get_target_coords,
-    gc_dist,
-    substitute_nans_by_fillvalue,
-    add_time_info_to_ds,
+    _from_yaml,
     _to_dict,
     _write_to_yaml,
-    _from_yaml,
+    add_time_info_to_ds,
     add_tracer_metadata_to_ds,
+    gc_dist,
+    get_target_coords,
     get_variable_metadata,
+    substitute_nans_by_fillvalue,
 )
+from roms_tools.utils import save_datasets
 
 
 @dataclass(kw_only=True)

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -1,36 +1,38 @@
-import xarray as xr
 import importlib.metadata
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-import numpy as np
-import matplotlib.pyplot as plt
 from pathlib import Path
-import logging
-from typing import Dict, Union, List, Optional
+from typing import Dict, List, Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
 from roms_tools import Grid
-from roms_tools.utils import save_datasets, transpose_dimensions
-from roms_tools.regrid import LateralRegridToROMS
 from roms_tools.plot import _plot
+from roms_tools.regrid import LateralRegridToROMS
 from roms_tools.setup.datasets import (
-    ERA5Dataset,
-    ERA5Correction,
     CESMBGCSurfaceForcingDataset,
+    ERA5Correction,
+    ERA5Dataset,
     UnifiedBGCSurfaceDataset,
 )
 from roms_tools.setup.utils import (
-    get_target_coords,
-    nan_check,
-    substitute_nans_by_fillvalue,
-    interpolate_from_climatology,
-    get_variable_metadata,
-    group_dataset,
-    rotate_velocities,
-    compute_missing_surface_bgc_variables,
-    add_time_info_to_ds,
+    _from_yaml,
     _to_dict,
     _write_to_yaml,
-    _from_yaml,
+    add_time_info_to_ds,
+    compute_missing_surface_bgc_variables,
+    get_target_coords,
+    get_variable_metadata,
+    group_dataset,
+    interpolate_from_climatology,
+    nan_check,
+    rotate_velocities,
+    substitute_nans_by_fillvalue,
 )
+from roms_tools.utils import save_datasets, transpose_dimensions
 
 
 @dataclass(kw_only=True)

--- a/roms_tools/setup/tides.py
+++ b/roms_tools/setup/tides.py
@@ -1,29 +1,31 @@
-from datetime import datetime
-import xarray as xr
-import numpy as np
-from typing import Dict, Union, List
 import importlib.metadata
-import matplotlib.pyplot as plt
-from pathlib import Path
 from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
 from roms_tools import Grid
 from roms_tools.plot import _plot
 from roms_tools.regrid import LateralRegridToROMS
-from roms_tools.utils import save_datasets
 from roms_tools.setup.datasets import TPXOManager
 from roms_tools.setup.utils import (
-    nan_check,
-    substitute_nans_by_fillvalue,
-    interpolate_from_rho_to_u,
-    interpolate_from_rho_to_v,
-    get_variable_metadata,
-    get_target_coords,
-    rotate_velocities,
-    get_vector_pairs,
+    _from_yaml,
     _to_dict,
     _write_to_yaml,
-    _from_yaml,
+    get_target_coords,
+    get_variable_metadata,
+    get_vector_pairs,
+    interpolate_from_rho_to_u,
+    interpolate_from_rho_to_v,
+    nan_check,
+    rotate_velocities,
+    substitute_nans_by_fillvalue,
 )
+from roms_tools.utils import save_datasets
 
 
 @dataclass(kw_only=True)

--- a/roms_tools/setup/topography.py
+++ b/roms_tools/setup/topography.py
@@ -1,13 +1,15 @@
-import time
 import logging
-import xarray as xr
-import numpy as np
-import gcm_filters
-from roms_tools.setup.utils import handle_boundaries
+import time
 import warnings
 from itertools import count
+
+import gcm_filters
+import numpy as np
+import xarray as xr
+
 from roms_tools.regrid import LateralRegridToROMS
 from roms_tools.setup.datasets import ETOPO5Dataset, SRTM15Dataset
+from roms_tools.setup.utils import handle_boundaries
 
 
 def _add_topography(

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -1,16 +1,17 @@
-from enum import StrEnum
-
-import xarray as xr
-import numpy as np
-from typing import Union, Any, Dict, Type, Sequence
-import pandas as pd
-import cftime
-from pathlib import Path
-from datetime import datetime
-from dataclasses import fields, asdict, is_dataclass
-from pydantic import BaseModel
 import importlib.metadata
+from dataclasses import asdict, fields, is_dataclass
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Dict, Sequence, Type, Union
+
+import cftime
+import numpy as np
+import pandas as pd
+import xarray as xr
 import yaml
+from pydantic import BaseModel
+
 from roms_tools.constants import R_EARTH
 from roms_tools.utils import interpolate_from_rho_to_u, interpolate_from_rho_to_v
 

--- a/roms_tools/tests/test_analysis/test_roms_output.py
+++ b/roms_tools/tests/test_analysis/test_roms_output.py
@@ -1,10 +1,12 @@
-import pytest
-from pathlib import Path
-import xarray as xr
-import numpy as np
-import os
 import logging
+import os
 from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
 from roms_tools import Grid, ROMSOutput
 from roms_tools.download import download_test_data
 

--- a/roms_tools/tests/test_regrid.py
+++ b/roms_tools/tests/test_regrid.py
@@ -1,6 +1,7 @@
-import pytest
 import numpy as np
+import pytest
 import xarray as xr
+
 from roms_tools.regrid import VerticalRegridToROMS
 
 try:
@@ -9,6 +10,7 @@ except ImportError:
     xesmf = None
 
 from roms_tools.regrid import LateralRegridFromROMS
+
 
 # Lateral regridding
 @pytest.mark.skipif(xesmf is None, reason="xesmf required")

--- a/roms_tools/tests/test_setup/test_boundary_forcing.py
+++ b/roms_tools/tests/test_setup/test_boundary_forcing.py
@@ -1,13 +1,15 @@
-import pytest
-from datetime import datetime
-import xarray as xr
-import numpy as np
-from roms_tools import Grid, BoundaryForcing
-import textwrap
-from roms_tools.download import download_test_data
-from conftest import calculate_data_hash
-from pathlib import Path
 import logging
+import textwrap
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from conftest import calculate_data_hash
+from roms_tools import BoundaryForcing, Grid
+from roms_tools.download import download_test_data
 
 
 @pytest.mark.parametrize(

--- a/roms_tools/tests/test_setup/test_cdr_forcing.py
+++ b/roms_tools/tests/test_setup/test_cdr_forcing.py
@@ -1,18 +1,20 @@
-import pytest
-from datetime import datetime, timedelta
-from pydantic import ValidationError
-from roms_tools import Grid, VolumeRelease, TracerPerturbation, CDRForcing
-from roms_tools.constants import NUM_TRACERS
 import logging
+from datetime import datetime, timedelta
 from pathlib import Path
-import xarray as xr
+
 import numpy as np
-from roms_tools.setup.cdr_forcing import (
-    ReleaseSimulationManager,
-    ReleaseCollector,
-    CDRForcingDatasetBuilder,
-)
+import pytest
+import xarray as xr
+from pydantic import ValidationError
+
 from conftest import calculate_file_hash
+from roms_tools import CDRForcing, Grid, TracerPerturbation, VolumeRelease
+from roms_tools.constants import NUM_TRACERS
+from roms_tools.setup.cdr_forcing import (
+    CDRForcingDatasetBuilder,
+    ReleaseCollector,
+    ReleaseSimulationManager,
+)
 from roms_tools.setup.cdr_release import ReleaseType
 
 try:

--- a/roms_tools/tests/test_setup/test_cdr_release.py
+++ b/roms_tools/tests/test_setup/test_cdr_release.py
@@ -1,15 +1,15 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
-from datetime import datetime
 from pydantic import ValidationError
 
 from roms_tools.setup.cdr_release import (
-    Flux,
     Concentration,
+    Flux,
     Release,
-    VolumeRelease,
     TracerPerturbation,
+    VolumeRelease,
 )
 from roms_tools.setup.utils import get_tracer_defaults
 

--- a/roms_tools/tests/test_setup/test_datasets.py
+++ b/roms_tools/tests/test_setup/test_datasets.py
@@ -1,18 +1,20 @@
-import pytest
 import logging
+from collections import OrderedDict
 from datetime import datetime
+from pathlib import Path
+
 import numpy as np
+import pytest
 import xarray as xr
+
+from roms_tools.download import download_test_data
 from roms_tools.setup.datasets import (
-    Dataset,
-    GLORYSDataset,
-    ERA5Correction,
     CESMBGCDataset,
+    Dataset,
+    ERA5Correction,
+    GLORYSDataset,
     TPXODataset,
 )
-from roms_tools.download import download_test_data
-from pathlib import Path
-from collections import OrderedDict
 
 
 @pytest.fixture

--- a/roms_tools/tests/test_setup/test_fill.py
+++ b/roms_tools/tests/test_setup/test_fill.py
@@ -1,7 +1,8 @@
-import pytest
-from roms_tools.setup.fill import LateralFill
 import numpy as np
+import pytest
 import xarray as xr
+
+from roms_tools.setup.fill import LateralFill
 
 
 @pytest.mark.parametrize(

--- a/roms_tools/tests/test_setup/test_grid.py
+++ b/roms_tools/tests/test_setup/test_grid.py
@@ -1,13 +1,15 @@
-import pytest
-import logging
-import xarray as xr
-from roms_tools import Grid
 import importlib.metadata
+import logging
 import textwrap
-from roms_tools.download import download_test_data
-from conftest import calculate_file_hash
-from roms_tools.constants import MAXIMUM_GRID_SIZE
 from pathlib import Path
+
+import pytest
+import xarray as xr
+
+from conftest import calculate_file_hash
+from roms_tools import Grid
+from roms_tools.constants import MAXIMUM_GRID_SIZE
+from roms_tools.download import download_test_data
 
 
 @pytest.fixture()

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -1,14 +1,16 @@
-import pytest
-from datetime import datetime
-from roms_tools import InitialConditions, Grid
-import xarray as xr
-import numpy as np
-import textwrap
 import logging
+import textwrap
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from conftest import calculate_data_hash
+from roms_tools import Grid, InitialConditions
 from roms_tools.download import download_test_data
 from roms_tools.setup.datasets import CESMBGCDataset, UnifiedBGCDataset
-from pathlib import Path
-from conftest import calculate_data_hash
 
 
 @pytest.mark.parametrize(

--- a/roms_tools/tests/test_setup/test_nesting.py
+++ b/roms_tools/tests/test_setup/test_nesting.py
@@ -1,17 +1,19 @@
-import pytest
-import xarray as xr
-import numpy as np
 import logging
 from pathlib import Path
-from roms_tools import Grid, ChildGrid
-from roms_tools.setup.utils import get_boundary_coords
+
+import numpy as np
+import pytest
+import xarray as xr
+
 from conftest import calculate_file_hash
+from roms_tools import ChildGrid, Grid
 from roms_tools.setup.nesting import (
+    compute_boundary_distance,
     interpolate_indices,
     map_child_boundaries_onto_parent_grid_indices,
-    compute_boundary_distance,
     modify_child_topography_and_mask,
 )
+from roms_tools.setup.utils import get_boundary_coords
 
 
 @pytest.fixture()

--- a/roms_tools/tests/test_setup/test_river_forcing.py
+++ b/roms_tools/tests/test_setup/test_river_forcing.py
@@ -1,12 +1,14 @@
-from roms_tools import RiverForcing, Grid
-import xarray as xr
-import numpy as np
-from datetime import datetime
-import textwrap
-from pathlib import Path
-import pytest
 import logging
+import textwrap
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
 from conftest import calculate_file_hash
+from roms_tools import Grid, RiverForcing
 
 
 @pytest.fixture

--- a/roms_tools/tests/test_setup/test_surface_forcing.py
+++ b/roms_tools/tests/test_setup/test_surface_forcing.py
@@ -1,12 +1,14 @@
-import pytest
+import logging
+import textwrap
 from datetime import datetime
+from pathlib import Path
+
+import pytest
 import xarray as xr
+
+from conftest import calculate_data_hash
 from roms_tools import Grid, SurfaceForcing
 from roms_tools.download import download_test_data
-import textwrap
-from pathlib import Path
-import logging
-from conftest import calculate_data_hash
 
 
 @pytest.fixture

--- a/roms_tools/tests/test_setup/test_tides.py
+++ b/roms_tools/tests/test_setup/test_tides.py
@@ -1,10 +1,12 @@
-import pytest
-from roms_tools import Grid, TidalForcing
-import xarray as xr
-from roms_tools.download import download_test_data
 import textwrap
 from pathlib import Path
+
+import pytest
+import xarray as xr
+
 from conftest import calculate_data_hash
+from roms_tools import Grid, TidalForcing
+from roms_tools.download import download_test_data
 
 
 @pytest.fixture(scope="session")

--- a/roms_tools/tests/test_setup/test_topography.py
+++ b/roms_tools/tests/test_setup/test_topography.py
@@ -1,10 +1,11 @@
-import pytest
-from roms_tools import Grid
-from roms_tools.setup.topography import _compute_rfactor
-from roms_tools.download import download_test_data
 import numpy as np
 import numpy.testing as npt
+import pytest
 from scipy.ndimage import label
+
+from roms_tools import Grid
+from roms_tools.download import download_test_data
+from roms_tools.setup.topography import _compute_rfactor
 
 
 def test_enclosed_regions():

--- a/roms_tools/tests/test_setup/test_utils.py
+++ b/roms_tools/tests/test_setup/test_utils.py
@@ -1,11 +1,13 @@
-from roms_tools import Grid, BoundaryForcing
-from roms_tools.setup.utils import interpolate_from_climatology
-from roms_tools.setup.datasets import ERA5Correction
-from roms_tools.download import download_test_data
-import xarray as xr
-import pytest
 from datetime import datetime
 from pathlib import Path
+
+import pytest
+import xarray as xr
+
+from roms_tools import BoundaryForcing, Grid
+from roms_tools.download import download_test_data
+from roms_tools.setup.datasets import ERA5Correction
+from roms_tools.setup.utils import interpolate_from_climatology
 
 
 def test_interpolate_from_climatology(use_dask):

--- a/roms_tools/tests/test_setup/test_validation.py
+++ b/roms_tools/tests/test_setup/test_validation.py
@@ -1,6 +1,7 @@
-import pytest
 import os
 import shutil
+
+import pytest
 import xarray as xr
 
 

--- a/roms_tools/tests/test_tiling/test_partition.py
+++ b/roms_tools/tests/test_tiling/test_partition.py
@@ -1,9 +1,10 @@
-import pytest
 from pathlib import Path
+
+import pytest
 import xarray.testing as xrt
 
-from roms_tools.tiling.partition import partition, partition_netcdf
 from roms_tools import Grid
+from roms_tools.tiling.partition import partition, partition_netcdf
 
 
 @pytest.fixture

--- a/roms_tools/tests/test_vertical_coordinate.py
+++ b/roms_tools/tests/test_vertical_coordinate.py
@@ -1,12 +1,12 @@
-import pytest
 import numpy as np
+import pytest
 import xarray as xr
 
 from roms_tools.vertical_coordinate import (
     compute_cs,
-    sigma_stretch,
     compute_depth,
     compute_depth_coordinates,
+    sigma_stretch,
 )
 
 

--- a/roms_tools/tiling/partition.py
+++ b/roms_tools/tiling/partition.py
@@ -1,9 +1,10 @@
 from numbers import Integral
+from pathlib import Path
+from typing import Union
 
 import numpy as np
 import xarray as xr
-from typing import Union
-from pathlib import Path
+
 from roms_tools.utils import save_datasets
 
 

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -1,10 +1,11 @@
-import xarray as xr
-import numpy as np
-from pathlib import Path
-import re
 import glob
 import logging
+import re
 import warnings
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
 
 
 def _load_data(

--- a/roms_tools/vertical_coordinate.py
+++ b/roms_tools/vertical_coordinate.py
@@ -1,9 +1,10 @@
 import numpy as np
 import xarray as xr
+
 from roms_tools.utils import (
-    transpose_dimensions,
     interpolate_from_rho_to_u,
     interpolate_from_rho_to_v,
+    transpose_dimensions,
 )
 
 


### PR DESCRIPTION
This PR is formatting-only shouldn't affect code. It enables import sorting via ruff's isort plugin. It looks like isort had some boilerplate configuration in the pyproject.toml already, but was not actually being called in pre-commit. I added the ruff hook in pyproject.toml, removed the unneeded isort config, and ran `pre-commit run --all-files`.