### PR TITLE
Allow larger bottom control parameter `theta_b`

### DIFF
--- a/docs/methods.md
+++ b/docs/methods.md
@@ -93,7 +93,7 @@ ROMS uses a terrain-following vertical coordinate system. The vertical coordinat
 |-------------------------------|------------------------------------------------------------|------|-------------------------|
 | $N$                            | Number of vertical layers                                  | -    | -                       |
 | $\theta_s$                          | Surface control parameter                                  | -    | $0 < \theta_s ≤ 10$          |
-| $\theta_b$                          | Bottom control parameter                                   | -    | $0 < \theta_b ≤ 4$
+| $\theta_b$                          | Bottom control parameter                                   | -    | $0 < \theta_b ≤ 10$
 | $h_c$                          | Critical depth                                             | m    | -                       |
 
 Following {cite}`shchepetkin_correction_2009` (see also Figure 2 in {cite}`lemarie_are_2012`), these parameters are used to create the vertical coordinate system as follows:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,7 @@
 * Introduce `TracerPerturbation` for tracer-only CDR scenarios ([#301](https://github.com/CWorthy-ocean/roms-tools/pull/301))
 * Add `.plot_tracer_flux()` method for visualizing tracer flux time series ([#301](https://github.com/CWorthy-ocean/roms-tools/pull/301))
 * Allow bigger grid sizes of up to 25000 km ([#311](https://github.com/CWorthy-ocean/roms-tools/pull/311))
+* Allow larger bottom control parameter `theta_b` up to 10 ([#317](https://github.com/CWorthy-ocean/roms-tools/pull/317))
 
 ### Breaking Changes
 

--- a/roms_tools/constants.py
+++ b/roms_tools/constants.py
@@ -1,5 +1,5 @@
 R_EARTH = 6371315.0  # Earth radius in meters
 MAXIMUM_GRID_SIZE = 25000  # in km
 UPPER_BOUND_THETA_S = 10  # upper bound for surface vertical stretching parameter
-UPPER_BOUND_THETA_B = 4  # upper bound for bottom vertical stretching parameter
+UPPER_BOUND_THETA_B = 10  # upper bound for bottom vertical stretching parameter
 NUM_TRACERS = 34  # Number of tracers (temperature, salinity, BGC tracers)

--- a/roms_tools/constants.py
+++ b/roms_tools/constants.py
@@ -1,3 +1,5 @@
 R_EARTH = 6371315.0  # Earth radius in meters
 MAXIMUM_GRID_SIZE = 25000  # in km
+UPPER_BOUND_THETA_S = 10  # upper bound for surface vertical stretching parameter
+UPPER_BOUND_THETA_B = 4  # upper bound for bottom vertical stretching parameter
 NUM_TRACERS = 34  # Number of tracers (temperature, salinity, BGC tracers)

--- a/roms_tools/setup/cdr_forcing.py
+++ b/roms_tools/setup/cdr_forcing.py
@@ -371,14 +371,14 @@ class CDRForcing(BaseModel):
             End datetime for the plot. If None, defaults to `self.end_time`.
         release_names : list[str], or str, optional
             A list of release names to plot.
-            If a string equal to INCLUDE_ALL_RELEASE_NAMES, all releases will be plotted.
-            Defaults to INCLUDE_ALL_RELEASE_NAMES.
+            If a string equal to "all", all releases will be plotted.
+            Defaults to "all".
 
         Raises
         ------
         ValueError
             If self.releases are not of type VolumeRelease.
-            If `release_names` is not a list of strings or INCLUDE_ALL_RELEASE_NAMES.
+            If `release_names` is not a list of strings or "all".
             If any of the specified release names do not exist in `self.releases`.
         """
 
@@ -428,14 +428,14 @@ class CDRForcing(BaseModel):
             End datetime for the plot. If None, defaults to `self.end_time`.
         release_names : list[str], or str, optional
             A list of release names to plot.
-            If a string equal to INCLUDE_ALL_RELEASE_NAMES, all releases will be plotted.
-            Defaults to INCLUDE_ALL_RELEASE_NAMES.
+            If a string equal to "all", all releases will be plotted.
+            Defaults to "all".
 
         Raises
         ------
         ValueError
             If self.releases are not of type VolumeRelease.
-            If `release_names` is not a list of strings or INCLUDE_ALL_RELEASE_NAMES.
+            If `release_names` is not a list of strings or "all".
             If any of the specified release names do not exist in `self.releases`.
             If `tracer_name` does not exist in self.ds["tracer_name"])
         """
@@ -499,14 +499,14 @@ class CDRForcing(BaseModel):
             End datetime for the plot. If None, defaults to `self.end_time`.
         release_names : list[str], or str, optional
             A list of release names to plot.
-            If a string equal to INCLUDE_ALL_RELEASE_NAMES, all releases will be plotted.
-            Defaults to INCLUDE_ALL_RELEASE_NAMES.
+            If a string equal to "all", all releases will be plotted.
+            Defaults to "all".
 
         Raises
         ------
         ValueError
             If self.releases are not of type TracerPerturbation.
-            If `release_names` is not a list of strings or INCLUDE_ALL_RELEASE_NAMES.
+            If `release_names` is not a list of strings or "all".
             If any of the specified release names do not exist in `self.releases`.
             If `tracer_name` does not exist in self.ds["tracer_name"])
         """

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -71,7 +71,7 @@ class Grid:
     theta_s : float, optional
         The surface control parameter. Must satisfy 0 < theta_s <= 10. The default is 5.0.
     theta_b : float, optional
-        The bottom control parameter. Must satisfy 0 < theta_b <= 4. The default is 2.0.
+        The bottom control parameter. Must satisfy 0 < theta_b <= 10. The default is 2.0.
     hc : float, optional
         The critical depth (in meters). The default is 300.0.
     verbose: bool, optional
@@ -80,7 +80,7 @@ class Grid:
     Raises
     ------
     ValueError
-        If you try to create a grid with domain size larger than 20000 km.
+        If you try to create a grid with domain size larger than 25000 km.
     """
 
     nx: int

--- a/roms_tools/tests/test_setup/test_grid.py
+++ b/roms_tools/tests/test_setup/test_grid.py
@@ -8,7 +8,11 @@ import xarray as xr
 
 from conftest import calculate_file_hash
 from roms_tools import Grid
-from roms_tools.constants import MAXIMUM_GRID_SIZE, UPPER_BOUND_THETA_S, UPPER_BOUND_THETA_B
+from roms_tools.constants import (
+    MAXIMUM_GRID_SIZE,
+    UPPER_BOUND_THETA_B,
+    UPPER_BOUND_THETA_S,
+)
 from roms_tools.download import download_test_data
 
 

--- a/roms_tools/tests/test_setup/test_grid.py
+++ b/roms_tools/tests/test_setup/test_grid.py
@@ -8,7 +8,7 @@ import xarray as xr
 
 from conftest import calculate_file_hash
 from roms_tools import Grid
-from roms_tools.constants import MAXIMUM_GRID_SIZE
+from roms_tools.constants import MAXIMUM_GRID_SIZE, UPPER_BOUND_THETA_S, UPPER_BOUND_THETA_B
 from roms_tools.download import download_test_data
 
 
@@ -449,9 +449,7 @@ def test_invalid_theta_s_value():
             center_lat=55,
             rot=10,
             N=3,
-            theta_s=11.0,  # Invalid value, should be 0 < theta_s <= 10
-            theta_b=2.0,
-            hc=250.0,
+            theta_s=UPPER_BOUND_THETA_S + 1,
         )
 
 
@@ -467,9 +465,7 @@ def test_invalid_theta_b_value():
             center_lat=55,
             rot=10,
             N=3,
-            theta_s=5.0,
-            theta_b=5.0,  # Invalid value, should be 0 < theta_b <= 4
-            hc=250.0,
+            theta_b=UPPER_BOUND_THETA_B + 1,
         )
 
 

--- a/roms_tools/tests/test_vertical_coordinate.py
+++ b/roms_tools/tests/test_vertical_coordinate.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from roms_tools.constants import UPPER_BOUND_THETA_B, UPPER_BOUND_THETA_S
 from roms_tools.vertical_coordinate import (
     compute_cs,
     compute_depth,
@@ -17,11 +18,15 @@ def test_compute_cs():
     assert cs.shape == sigma.shape
     assert np.all(cs <= 0) and np.all(cs >= -1)
 
-    with pytest.raises(ValueError, match="theta_s must be between 0 and 10"):
-        compute_cs(sigma, 15, 2)
+    with pytest.raises(
+        ValueError, match=f"theta_s must be between 0 and {UPPER_BOUND_THETA_S}"
+    ):
+        compute_cs(sigma, UPPER_BOUND_THETA_S + 1, theta_b)
 
-    with pytest.raises(ValueError, match="theta_b must be between 0 and 4"):
-        compute_cs(sigma, 5, 5)
+    with pytest.raises(
+        ValueError, match=f"theta_b must be between 0 and {UPPER_BOUND_THETA_B}"
+    ):
+        compute_cs(sigma, theta_s, UPPER_BOUND_THETA_B + 1)
 
 
 def test_sigma_stretch():

--- a/roms_tools/vertical_coordinate.py
+++ b/roms_tools/vertical_coordinate.py
@@ -1,6 +1,7 @@
 import numpy as np
 import xarray as xr
 
+from roms_tools.constants import UPPER_BOUND_THETA_B, UPPER_BOUND_THETA_S
 from roms_tools.utils import (
     interpolate_from_rho_to_u,
     interpolate_from_rho_to_v,
@@ -31,10 +32,10 @@ def compute_cs(sigma, theta_s, theta_b):
     ValueError
         If theta_s or theta_b are not within the valid range.
     """
-    if not (0 < theta_s <= 10):
-        raise ValueError("theta_s must be between 0 and 10.")
-    if not (0 < theta_b <= 4):
-        raise ValueError("theta_b must be between 0 and 4.")
+    if not (0 < theta_s <= UPPER_BOUND_THETA_S):
+        raise ValueError(f"theta_s must be between 0 and {UPPER_BOUND_THETA_S}.")
+    if not (0 < theta_b <= UPPER_BOUND_THETA_B):
+        raise ValueError(f"theta_b must be between 0 and {UPPER_BOUND_THETA_B}.")
 
     C = (1 - np.cosh(theta_s * sigma)) / (np.cosh(theta_s) - 1)
     C = (np.exp(theta_b * C) - 1) / (1 - np.exp(-theta_b))


### PR DESCRIPTION
This PR bumps up the upper limit of `theta_b` to 10, as discussed in https://github.com/CWorthy-ocean/roms-tools/issues/310. It also introduces a global constant `UPPER_BOUND_THETA_B` (and its companion `UPPER_BOUND_THETA_S`), so that we can easily change these numbers in the future.

I have also updated the notebook in the documentation to show the vertical layers with `theta_b = 6`.

- [x] Closes #312
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
- [x] New functions/methods are listed in `docs/api.rst`
- [x] New functionality has documentation
