### PR TITLE
Duplicates

### DIFF
--- a/roms_tools/tests/test_setup/test_boundary_forcing.py
+++ b/roms_tools/tests/test_setup/test_boundary_forcing.py
@@ -58,6 +58,25 @@ def test_boundary_forcing_creation(boundary_forcing_fixture, request):
     assert hasattr(boundary_forcing.ds, "apply_2d_horizontal_fill")
 
 
+def test_boundary_forcing_creation_with_duplicates(boundary_forcing, use_dask):
+    """Test the creation of the BoundaryForcing object with duplicates in source data
+    works as expected."""
+
+    fname1 = Path(download_test_data("GLORYS_NA_20120101.nc"))
+    fname2 = Path(download_test_data("GLORYS_NA_20121231.nc"))
+
+    boundary_forcing_with_duplicates_in_source_data = BoundaryForcing(
+        grid=boundary_forcing.grid,
+        start_time=boundary_forcing.start_time,
+        end_time=boundary_forcing.end_time,
+        source={"name": "GLORYS", "path": [fname1, fname1, fname2]},
+        apply_2d_horizontal_fill=boundary_forcing.apply_2d_horizontal_fill,
+        use_dask=use_dask,
+    )
+
+    boundary_forcing.ds.identical(boundary_forcing_with_duplicates_in_source_data.ds)
+
+
 @pytest.mark.parametrize(
     "boundary_forcing_fixture",
     [

--- a/roms_tools/tests/test_setup/test_initial_conditions.py
+++ b/roms_tools/tests/test_setup/test_initial_conditions.py
@@ -45,6 +45,43 @@ def test_initial_conditions_creation(ic_fixture, request):
     assert ic.ds.coords["ocean_time"].attrs["units"] == "seconds"
 
 
+def test_initial_conditions_creation_with_duplicates(use_dask):
+    """Test the creation of the InitialConditions object with duplicates in source data
+    works as expected."""
+
+    fname1 = Path(download_test_data("GLORYS_NA_20120101.nc"))
+    fname2 = Path(download_test_data("GLORYS_NA_20121231.nc"))
+
+    grid = Grid(
+        nx=3,
+        ny=3,
+        size_x=400,
+        size_y=400,
+        center_lon=-8,
+        center_lat=58,
+        rot=0,
+        N=3,
+    )
+
+    initial_conditions = InitialConditions(
+        grid=grid,
+        ini_time=datetime(2012, 1, 1),
+        source={"path": [fname1, fname2], "name": "GLORYS"},
+        use_dask=use_dask,
+    )
+
+    initial_conditions_with_duplicates_in_source_data = InitialConditions(
+        grid=grid,
+        ini_time=datetime(2012, 1, 1),
+        source={"path": [fname1, fname1, fname2], "name": "GLORYS"},
+        use_dask=use_dask,
+    )
+
+    initial_conditions.ds.identical(
+        initial_conditions_with_duplicates_in_source_data.ds
+    )
+
+
 @pytest.mark.parametrize(
     "ic_fixture",
     [

--- a/roms_tools/utils.py
+++ b/roms_tools/utils.py
@@ -174,6 +174,9 @@ def _load_data(
     if "time" in dim_names and dim_names["time"] not in ds.dims:
         ds = ds.expand_dims(dim_names["time"])
 
+    if "time" in dim_names:
+        ds = ds.drop_duplicates(dim=dim_names["time"])
+
     return ds
 
 


### PR DESCRIPTION
This PR adds the feature that the user can provide source data with **duplicate** time entries as requested by @abigale-wyatt in #332. 

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in `docs/api.rst`
- [ ] New functionality has documentation
