### PR TITLE
Fix plotting `ROMSOutput` for grid that straddle the dateline

### DIFF
--- a/roms_tools/analysis/roms_output.py
+++ b/roms_tools/analysis/roms_output.py
@@ -214,6 +214,11 @@ class ROMSOutput:
         lon_deg = self.grid.ds[f"lon_{loc}"]
         if self.grid.straddle:
             lon_deg = xr.where(lon_deg > 180, lon_deg - 360, lon_deg)
+            if lon is not None:
+                lon = lon if lon > 180 else lon
+            else:
+                lon = lon if lon < 0 else lon - 360
+
         field = field.assign_coords({"lon": lon_deg, "lat": lat_deg})
 
         # Mask the field

--- a/roms_tools/tests/test_analysis/test_roms_output.py
+++ b/roms_tools/tests/test_analysis/test_roms_output.py
@@ -44,15 +44,27 @@ def roms_output_from_restart_file_adjusted_for_zeta(use_dask):
         use_dask=use_dask,
     )
 
+@pytest.fixture
+def roms_output_from_restart_file_with_straddling_grid(use_dask):
+
+    # Make fake grid that straddles the dateline and that has consistent sizes with test data below
+    grid = Grid(nx=8, ny=13, center_lon=0, center_lat=60, rot=32, size_x=244, size_y=365)
+
+    return ROMSOutput(
+        grid=grid,
+        path=Path(download_test_data("eastpac25km_rst.19980106000000.nc")),
+        use_dask=use_dask,
+    )
 
 @pytest.mark.parametrize(
     "roms_output_fixture",
     [
         "roms_output_from_restart_file",
         "roms_output_from_restart_file_adjusted_for_zeta",
+        "roms_output_from_restart_file_with_straddling_grid"
     ],
 )
-def test_load_model_output_file(roms_output_fixture, use_dask, request):
+def test_load_model_output_file(roms_output_fixture, request):
     roms_output = request.getfixturevalue(roms_output_fixture)
 
     assert isinstance(roms_output.ds, xr.Dataset)
@@ -271,9 +283,10 @@ def test_that_coordinates_are_added(use_dask):
     [
         "roms_output_from_restart_file",
         "roms_output_from_restart_file_adjusted_for_zeta",
+        "roms_output_from_restart_file_with_straddling_grid"
     ],
 )
-def test_plot_on_native_model_grid(roms_output_fixture, use_dask, request):
+def test_plot_on_native_model_grid(roms_output_fixture, request):
     roms_output = request.getfixturevalue(roms_output_fixture)
 
     for include_boundary in [False, True]:
@@ -341,10 +354,11 @@ def test_plot_on_native_model_grid(roms_output_fixture, use_dask, request):
     [
         "roms_output_from_restart_file",
         "roms_output_from_restart_file_adjusted_for_zeta",
+        "roms_output_from_restart_file_with_straddling_grid"
     ],
 )
 @pytest.mark.skipif(xesmf is None, reason="xesmf required")
-def test_plot_on_lat_lon(roms_output_fixture, use_dask, request):
+def test_plot_on_lat_lon(roms_output_fixture, request):
     roms_output = request.getfixturevalue(roms_output_fixture)
 
     for include_boundary in [False, True]:
@@ -409,7 +423,7 @@ def test_plot_on_lat_lon(roms_output_fixture, use_dask, request):
             roms_output.plot("zeta", time=1, lon=-128, **kwargs)
 
 
-def test_plot_errors(roms_output_from_restart_file, use_dask):
+def test_plot_errors(roms_output_from_restart_file):
     """Test error conditions for the ROMSOutput.plot() method."""
 
     # Invalid time index
@@ -491,12 +505,21 @@ def test_figure_gets_saved(roms_output_from_restart_file, tmp_path):
     filename.unlink()
 
 
+@pytest.mark.parametrize(
+    "roms_output_fixture",
+    [
+        "roms_output_from_restart_file",
+        "roms_output_from_restart_file_adjusted_for_zeta",
+        "roms_output_from_restart_file_with_straddling_grid"
+    ],
+)
 @pytest.mark.skipif(xesmf is None, reason="xesmf required")
-def test_regrid_all_variables(roms_output_from_restart_file):
-    ds_regridded = roms_output_from_restart_file.regrid()
+def test_regrid_all_variables(roms_output_fixture, request):
+    roms_output = request.getfixturevalue(roms_output_fixture)
+    ds_regridded = roms_output.regrid()
     assert isinstance(ds_regridded, xr.Dataset)
     assert set(ds_regridded.data_vars).issubset(
-        set(roms_output_from_restart_file.ds.data_vars)
+        set(roms_output.ds.data_vars)
     )
     assert "lon" in ds_regridded.coords
     assert "lat" in ds_regridded.coords
@@ -504,28 +527,55 @@ def test_regrid_all_variables(roms_output_from_restart_file):
     assert "time" in ds_regridded.coords
 
 
+@pytest.mark.parametrize(
+    "roms_output_fixture",
+    [
+        "roms_output_from_restart_file",
+        "roms_output_from_restart_file_adjusted_for_zeta",
+        "roms_output_from_restart_file_with_straddling_grid"
+    ],
+)
 @pytest.mark.skipif(xesmf is None, reason="xesmf required")
-def test_regrid_specific_variables(roms_output_from_restart_file):
+def test_regrid_specific_variables(roms_output_fixture, request):
+    roms_output = request.getfixturevalue(roms_output_fixture)
     var_names = ["temp", "salt"]
-    ds_regridded = roms_output_from_restart_file.regrid(var_names=var_names)
+    ds_regridded = roms_output.regrid(var_names=var_names)
     assert isinstance(ds_regridded, xr.Dataset)
     assert set(ds_regridded.data_vars) == set(var_names)
 
-    ds = roms_output_from_restart_file.regrid(var_names=[])
+    ds = roms_output.regrid(var_names=[])
     assert ds is None
 
 
+@pytest.mark.parametrize(
+    "roms_output_fixture",
+    [
+        "roms_output_from_restart_file",
+        "roms_output_from_restart_file_adjusted_for_zeta",
+        "roms_output_from_restart_file_with_straddling_grid"
+    ],
+)
 @pytest.mark.skipif(xesmf is None, reason="xesmf required")
-def test_regrid_missing_variable_raises_error(roms_output_from_restart_file):
+def test_regrid_missing_variable_raises_error(roms_output_fixture, request):
+    roms_output = request.getfixturevalue(roms_output_fixture)
     with pytest.raises(
         ValueError, match="The following variables are not found in the dataset"
     ):
-        roms_output_from_restart_file.regrid(var_names=["fake_variable"])
+        roms_output.regrid(var_names=["fake_variable"])
 
 
+@pytest.mark.parametrize(
+    "roms_output_fixture",
+    [
+        "roms_output_from_restart_file",
+        "roms_output_from_restart_file_adjusted_for_zeta",
+        "roms_output_from_restart_file_with_straddling_grid"
+    ],
+)
 @pytest.mark.skipif(xesmf is None, reason="xesmf required")
-def test_regrid_with_custom_horizontal_resolution(roms_output_from_restart_file):
-    ds_regridded = roms_output_from_restart_file.regrid(horizontal_resolution=0.1)
+def test_regrid_with_custom_horizontal_resolution(roms_output_fixture, request):
+    roms_output = request.getfixturevalue(roms_output_fixture)
+    ds_regridded = roms_output.regrid(horizontal_resolution=0.1)
     assert isinstance(ds_regridded, xr.Dataset)
     assert "lon" in ds_regridded.coords
     assert "lat" in ds_regridded.coords
@@ -534,12 +584,21 @@ def test_regrid_with_custom_horizontal_resolution(roms_output_from_restart_file)
     assert np.allclose(ds_regridded.lat.diff(dim="lat"), 0.1, atol=1e-4)
 
 
+@pytest.mark.parametrize(
+    "roms_output_fixture",
+    [
+        "roms_output_from_restart_file",
+        "roms_output_from_restart_file_adjusted_for_zeta",
+        "roms_output_from_restart_file_with_straddling_grid"
+    ],
+)
 @pytest.mark.skipif(xesmf is None, reason="xesmf required")
-def test_regrid_with_custom_depth_levels(roms_output_from_restart_file):
+def test_regrid_with_custom_depth_levels(roms_output_fixture, request):
+    roms_output = request.getfixturevalue(roms_output_fixture)
     depth_levels = xr.DataArray(
         np.linspace(0, 500, 51), dims=["depth"], attrs={"units": "m"}
     )
-    ds_regridded = roms_output_from_restart_file.regrid(depth_levels=depth_levels)
+    ds_regridded = roms_output.regrid(depth_levels=depth_levels)
     assert isinstance(ds_regridded, xr.Dataset)
     assert "depth" in ds_regridded.coords
     np.allclose(ds_regridded.depth, depth_levels, atol=0.0)


### PR DESCRIPTION
This PR addresses #346. It
* fixes a small bug so that `ROMSOutput` can now also plot data for grids that straddle the dateline;
* adds tests that test the previous bullet point

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in `docs/api.rst`
- [ ] New functionality has documentation