### PR TITLE
Adding short helper to find ROMS output

### DIFF
--- a/docs/plotting_roms_output.ipynb
+++ b/docs/plotting_roms_output.ipynb
@@ -115,7 +115,7 @@
    "id": "a8266ffc-ec66-4859-8480-1f61d985d930",
    "metadata": {},
    "source": [
-    "To plot ROMS output on its native grid, we can specify horizontal or vertical slices by specifying combinations of (`eta`, `xi`, `s`)—the three primary dimensions in ROMS. "
+    "To plot ROMS output on its native grid, we can specify horizontal or vertical slices by specifying combinations of (`eta`, `xi`, `s`)—the three primary dimensions in ROMS. To see ROMS outputs available for plotting, use `roms_output.ds`."
    ]
   },
   {


### PR DESCRIPTION
Adding a sentence to the notebook for `Visualizing ROMS output`, just to make it a little easier to understand what variables are able to be plotted. 
It's particularly helpful if the reader is using a different output file type than the one in the example given (avg vs rst for example), and they aren't able to plot the example variables. 

Resolves: #364 