### PR TITLE
Optimize wind drop-off minimum distance calculation

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* Optimize wind drop-off calculation to avoid out-of-memory errors.
 * Option to stream ERA5 data directly from the cloud so that users do not have to pre-download ERA5 data ([#357](https://github.com/CWorthy-ocean/roms-tools/pull/357))
 * Option for wind drop-off near the coasts in `SurfaceForcing` ([#351](https://github.com/CWorthy-ocean/roms-tools/pull/351))
 * Option to ignore coarse dimensions when partitioning ([#348](https://github.com/CWorthy-ocean/roms-tools/pull/348))

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -26,11 +26,11 @@ from roms_tools.setup.utils import (
     _write_to_yaml,
     add_time_info_to_ds,
     compute_missing_surface_bgc_variables,
-    gc_dist,
     get_target_coords,
     get_variable_metadata,
     group_dataset,
     interpolate_from_climatology,
+    min_dist_between_point_arrays,
     nan_check,
     rotate_velocities,
     substitute_nans_by_fillvalue,
@@ -498,22 +498,32 @@ class SurfaceForcing:
             Corrected meridional wind component with reduced coastal values.
         """
 
+        cdist = np.empty_like(self.target_coords["lon"].values)
+        min_dist_between_point_arrays(
+            self.target_coords["lon"].values,
+            self.target_coords["lat"].values,
+            self.target_coords["lon"].where(1 - self.target_coords["mask"]).values,
+            self.target_coords["lat"].where(1 - self.target_coords["mask"]).values,
+            cdist,
+        )
         # Compute great-circle distance from each grid point to the nearest land point
-        dist_mask = gc_dist(
-            self.target_coords["lon"].where(1 - self.target_coords["mask"]),
-            self.target_coords["lat"].where(1 - self.target_coords["mask"]),
-            self.target_coords["lon"].rename({"eta_rho": "eta", "xi_rho": "xi"}),
-            self.target_coords["lat"].rename({"eta_rho": "eta", "xi_rho": "xi"}),
-        )
-        # Find the minimum distance to land for each ocean point (in meters)
-        cdist = dist_mask.min(dim=["eta_rho", "xi_rho"]).rename(
-            {"eta": "eta_rho", "xi": "xi_rho"}
-        )
+        # dist_mask = gc_dist(
+        #     self.target_coords["lon"].where(1 - self.target_coords["mask"]),
+        #     self.target_coords["lat"].where(1 - self.target_coords["mask"]),
+        #     self.target_coords["lon"].rename({"eta_rho": "eta", "xi_rho": "xi"}),
+        #     self.target_coords["lat"].rename({"eta_rho": "eta", "xi_rho": "xi"}),
+        # )
+        # # Find the minimum distance to land for each ocean point (in meters)
+        # cdist = dist_mask.min(dim=["eta_rho", "xi_rho"]).rename(
+        #     {"eta": "eta_rho", "xi": "xi_rho"}
+        # )
 
         # Compute a spatially varying scaling factor to reduce wind near the coast.
         # This uses an exponential decay with a 12.5 km e-folding scale,
         # reducing wind magnitude by up to 40% at the coastline.
         mult = 1 - 0.4 * np.exp(-0.08 * cdist / 1000)
+
+        mult = xr.DataArray(data=mult, dims=["eta_rho", "xi_rho"])
 
         uwnd_corrected = mult * uwnd
         vwnd_corrected = mult * vwnd

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -30,7 +30,7 @@ from roms_tools.setup.utils import (
     get_variable_metadata,
     group_dataset,
     interpolate_from_climatology,
-    min_dist_between_point_arrays_in_degrees,
+    min_dist_to_land_2,
     nan_check,
     rotate_velocities,
     substitute_nans_by_fillvalue,
@@ -498,14 +498,42 @@ class SurfaceForcing:
             Corrected meridional wind component with reduced coastal values.
         """
 
-        cdist = np.empty_like(self.target_coords["lon"].values)
-        min_dist_between_point_arrays_in_degrees(
+        # ocean_lon = self.target_coords["lon"].where(self.target_coords["mask"], drop=True).values
+        # ocean_lat = self.target_coords["lat"].where(self.target_coords["mask"], drop=True).values
+        # land_lon = self.target_coords["lon"].where(1 - self.target_coords["mask"], drop=True).values
+        # land_lat = self.target_coords["lat"].where(1 - self.target_coords["mask"], drop=True).values
+        # cdist = np.zeros_like(self.target_coords["lon"].values)
+        # min_dist_between_point_arrays_in_degrees(
+        #     self.target_coords["lon"].values,
+        #     self.target_coords["lat"].values,
+        #     self.target_coords["lon"].where(1 - self.target_coords["mask"]).values,
+        #     self.target_coords["lat"].where(1 - self.target_coords["mask"]).values,
+        #     cdist,
+        # )
+        # min_dist_between_point_arrays_in_degrees(
+        #     self.target_coords["lon"].values,
+        #     self.target_coords["lat"].values,
+        #     self.target_coords["lon"].where(1 - self.target_coords["mask"]).values,
+        #     self.target_coords["lat"].where(1 - self.target_coords["mask"]).values,
+        #     cdist,
+        # )
+
+        # ocean_lon = self.target_coords["lon"].where(self.target_coords["mask"], drop=True).values
+        # ocean_lat = self.target_coords["lat"].where(self.target_coords["mask"], drop=True).values
+        # land_lon = self.target_coords["lon"].where(1 - self.target_coords["mask"], drop=True).values
+        # land_lat = self.target_coords["lat"].where(1 - self.target_coords["mask"], drop=True).values
+        cdist = np.full_like(self.target_coords["lon"].values, 0)
+        min_dist_to_land_2(
             self.target_coords["lon"].values,
             self.target_coords["lat"].values,
-            self.target_coords["lon"].where(1 - self.target_coords["mask"]).values,
-            self.target_coords["lat"].where(1 - self.target_coords["mask"]).values,
+            self.target_coords["mask"].values,
             cdist,
         )
+
+        # cdist[:,:] = np.nanmin(
+        #     _gc_dist_degrees(self.target_coords["lon"][:,:], self.target_coords["lat"][:,:], self.target_coords["lon"].where(1 - self.target_coords["mask"]), self.target_coords["lat"].where(1 - self.target_coords["mask"]))
+        # )
+
         # Compute great-circle distance from each grid point to the nearest land point
         # dist_mask = gc_dist(
         #     self.target_coords["lon"].where(1 - self.target_coords["mask"]),
@@ -523,6 +551,7 @@ class SurfaceForcing:
         # reducing wind magnitude by up to 40% at the coastline.
         mult = 1 - 0.4 * np.exp(-0.08 * cdist / 1000)
 
+        print(mult)
         mult = xr.DataArray(data=mult, dims=["eta_rho", "xi_rho"])
 
         uwnd_corrected = mult * uwnd

--- a/roms_tools/setup/surface_forcing.py
+++ b/roms_tools/setup/surface_forcing.py
@@ -30,7 +30,7 @@ from roms_tools.setup.utils import (
     get_variable_metadata,
     group_dataset,
     interpolate_from_climatology,
-    min_dist_between_point_arrays,
+    min_dist_between_point_arrays_in_degrees,
     nan_check,
     rotate_velocities,
     substitute_nans_by_fillvalue,
@@ -499,7 +499,7 @@ class SurfaceForcing:
         """
 
         cdist = np.empty_like(self.target_coords["lon"].values)
-        min_dist_between_point_arrays(
+        min_dist_between_point_arrays_in_degrees(
             self.target_coords["lon"].values,
             self.target_coords["lat"].values,
             self.target_coords["lon"].where(1 - self.target_coords["mask"]).values,

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -1473,48 +1473,6 @@ def _min_dist_to_land4(
 # print("stop")
 
 
-def min_dist_to_land_2(
-    lon: np.ndarray,
-    lat: np.ndarray,
-    mask: np.ndarray,
-    result: np.ndarray,
-):
-    """Calculate the distance between one set of points (lon1, lat1) to the closest of
-    another set of points (lon2, lat2).
-
-    Parameters
-    ----------
-    lon1, lat1 : np.ndarray
-        2-D Arrays of longitude and latitude of the first set of points (origin points).
-    lon2, lat2 : np.ndarray
-        2-D Arrays of longitude and latitude of the second set of points (target points).
-    result: np.ndarray
-        2-D Array of the same shape as lon1, lat1, which will be filled with the resulting distance values
-        to the nearest non-nan lon2, lat2 point
-
-    Returns
-    -------
-    None (output is stored in `result` input array)
-    """
-    ocean = (mask == 1).ravel()
-    land = (mask == 0).ravel()
-    ocean_lon = lon.ravel()[ocean]
-    ocean_lat = lat.ravel()[ocean]
-    land_lon = lon.ravel()[land]
-    land_lat = lat.ravel()[land]
-    ocean_indices = mask.nonzero()
-    # land_indices = (~mask).nonzero()
-    _min_dist_to_land3(
-        ocean_lon,
-        ocean_lat,
-        land_lon,
-        land_lat,
-        ocean_indices[0],
-        ocean_indices[1],
-        result,
-    )
-
-
 @nb.njit(
     [
         nb.void(
@@ -1560,6 +1518,64 @@ def _min_dist_to_land3(
         result[ocean_indices_lon[i], ocean_indices_lat[i]] = np.min(
             _gc_dist_degrees(ocean_lon[i], ocean_lat[i], land_lon, land_lat)
         )
+
+
+@nb.njit(
+    [
+        nb.void(
+            nb.float64[:, :],
+            nb.float64[:, :],
+            nb.int32[:, :],
+            nb.float64[:, :],
+        )
+    ],
+    parallel=True,
+)
+def min_dist_to_land_2(
+    lon: np.ndarray,
+    lat: np.ndarray,
+    mask: np.ndarray,
+    result: np.ndarray,
+):
+    """Calculate the distance between one set of points (lon1, lat1) to the closest of
+    another set of points (lon2, lat2).
+
+    Parameters
+    ----------
+    lon1, lat1 : np.ndarray
+        2-D Arrays of longitude and latitude of the first set of points (origin points).
+    lon2, lat2 : np.ndarray
+        2-D Arrays of longitude and latitude of the second set of points (target points).
+    result: np.ndarray
+        2-D Array of the same shape as lon1, lat1, which will be filled with the resulting distance values
+        to the nearest non-nan lon2, lat2 point
+
+    Returns
+    -------
+    None (output is stored in `result` input array)
+    """
+    ocean = (mask == 1).ravel()
+    land = (mask == 0).ravel()
+    ocean_lon = lon.ravel()[ocean]
+    ocean_lat = lat.ravel()[ocean]
+    land_lon = lon.ravel()[land]
+    land_lat = lat.ravel()[land]
+    ocean_indices = mask.nonzero()
+    # land_indices = (~mask).nonzero()
+    _min_dist_to_land3(
+        ocean_lon,
+        ocean_lat,
+        land_lon,
+        land_lat,
+        ocean_indices[0],
+        ocean_indices[1],
+        result,
+    )
+
+    # for i in nb.prange(ocean_lon.shape[0]):
+    #         result[ocean_indices[0][i], ocean_indices[1][i]] = np.min(
+    #             _gc_dist_degrees(ocean_lon[i], ocean_lat[i], land_lon, land_lat)
+    #         )
 
     # print("stop")
 


### PR DESCRIPTION
This PR eliminates the need to store a very large array in memory that contains the distances between all points during the wind drop-off calculation. It uses `numba` to optimize a for loop that handles the minimum calculation in-line for each array entry, rather than storing the extra array layer and calculating the minimum later. There is probably a clever way to write this in vectorized numpy, without numba, but I couldn't get it to work quite right and this gets the job done. On Perlmutter, the calculation takes less than 5 minutes for the large Pacific domain.

- [ ] Closes #359 
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in `docs/api.rst`
- [ ] New functionality has documentation
