### PR TITLE
Fix bug incorrectly identifying CDR releases as outside the domain

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,6 +12,8 @@
 
 ### Bugfixes
 
+* Fix bug incorrectly identifying CDR releases as outside the domain ([#377](https://github.com/CWorthy-ocean/roms-tools/pull/377))
+
 ## v3.0.0
 
 ### New Features

--- a/roms_tools/setup/cdr_forcing.py
+++ b/roms_tools/setup/cdr_forcing.py
@@ -946,13 +946,18 @@ def _validate_release_location(grid, release: Release):
 
         dx = 1 / grid.ds.pm
         dy = 1 / grid.ds.pn
-        max_grid_spacing = np.sqrt(dx**2 + dy**2) / 2
+
+        # Compute the maximum half-diagonal grid spacing across the domain
+        max_grid_spacing = (np.sqrt(dx**2 + dy**2) / 2).max()
+
+        # Apply a 10% safety margin
+        max_grid_spacing *= 1.1
 
         # Compute great-circle distance to all grid points
         dist = gc_dist(grid.ds.lon_rho, grid.ds.lat_rho, lon, release.lat)
         dist_min = dist.min(dim=["eta_rho", "xi_rho"])
 
-        if (dist_min > max_grid_spacing).all():
+        if dist_min > max_grid_spacing:
             raise ValueError(
                 f"Release site '{release.name}' is outside of the grid domain. "
                 "Ensure the provided (lat, lon) falls within the model grid extent."


### PR DESCRIPTION
To fix this bug, we apply a 10% safety margin to maximum grid spacing threshold for CDR forcing.

- [x] Closes #376
- [x] Changes are documented in `docs/releases.md`
