### PR TITLE
Introduce `BaseGrid` to separate shared and class-specific methods

### DIFF
--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -28,7 +28,7 @@ from roms_tools.vertical_coordinate import compute_depth_coordinates, sigma_stre
 
 
 @dataclass(kw_only=True)
-class Grid:
+class BaseGrid:
     """A single ROMS grid, used for creating, plotting, and then saving a new ROMS
     domain grid.
 
@@ -531,227 +531,6 @@ class Grid:
 
         return saved_filenames
 
-    @classmethod
-    def from_file(
-        cls,
-        filepath: str | Path,
-        theta_s: float | None = None,
-        theta_b: float | None = None,
-        hc: float | None = None,
-        N: int | None = None,
-        verbose: bool = False,
-    ) -> "Grid":
-        """Create a Grid instance from an existing file.
-
-        Parameters
-        ----------
-        filepath : Union[str, Path]
-            Path to the file containing the grid information.
-        theta_s : float, optional
-            Surface stretching parameter for vertical coordinate.
-        theta_b : float, optional
-            Bottom stretching parameter for vertical coordinate.
-        hc : float, optional
-            Critical depth for vertical coordinate.
-        N : int, optional
-            Number of vertical levels for vertical coordinate.
-        verbose: bool, optional
-            Indicates whether to print grid generation steps with timing. Defaults to False.
-
-        Returns
-        -------
-        Grid
-            A new instance of Grid populated with data from the file.
-        """
-        # Validate that either all or none of the vertical grid parameters are provided
-        user_params = [theta_s, theta_b, hc, N]
-        num_provided = sum(p is not None for p in user_params)
-        if 0 < num_provided < 4:
-            raise ValueError(
-                "If specifying vertical coordinate parameters, you must provide all of: "
-                "theta_s, theta_b, hc, and N."
-            )
-
-        # Load the dataset from the file
-        ds = xr.open_dataset(filepath)
-
-        if not all(mask in ds for mask in ["mask_u", "mask_v"]):
-            ds = _add_velocity_masks(ds)
-
-        # Create a new Grid instance without calling __init__ and __post_init__
-        grid = cls.__new__(cls)
-
-        # Set the dataset for the grid instance
-        grid.ds = ds
-
-        # Check if the Greenwich meridian goes through the domain.
-        grid._straddle()
-
-        if not all(coord in grid.ds for coord in ["lat_u", "lon_u", "lat_v", "lon_v"]):
-            ds = _add_lat_lon_at_velocity_points(grid.ds, grid.straddle)
-            grid.ds = ds
-
-        # Coarsen the grid if necessary
-        if not all(
-            var in grid.ds
-            for var in [
-                "lon_coarse",
-                "lat_coarse",
-                "angle_coarse",
-                "mask_coarse",
-            ]
-        ):
-            grid._coarsen()
-
-        # Move variables to coordinates if necessary
-        for var in ["lat_rho", "lon_rho", "lat_coarse", "lon_coarse"]:
-            if var not in ds.coords:
-                ds = grid.ds.set_coords(var)
-                grid.ds = ds
-
-        # Check if vertical coordinates already exist
-        if all(var in grid.ds for var in ["Cs_r", "Cs_w"]):
-            prior_Cs_r = grid.ds.Cs_r.copy(deep=True)
-            prior_Cs_w = grid.ds.Cs_w.copy(deep=True)
-        else:
-            prior_Cs_r = None
-            prior_Cs_w = None
-
-        # Case: user provides all vertical coordinate parameters
-        if num_provided == 4:
-            grid.update_vertical_coordinate(
-                N=N, theta_s=theta_s, theta_b=theta_b, hc=hc, verbose=True
-            )
-
-            if prior_Cs_r is not None and prior_Cs_w is not None:
-                # Check for consistency between provided and file-stored vertical coordinates
-                if (grid.ds.Cs_r.shape != prior_Cs_r.shape) or (
-                    grid.ds.Cs_w.shape != prior_Cs_w.shape
-                ):
-                    raise ValueError(
-                        "The grid file contains vertical coordinates (Cs_r, Cs_w), but their shapes "
-                        "are inconsistent with the provided N."
-                    )
-                if not (
-                    np.allclose(grid.ds.Cs_r, prior_Cs_r)
-                    and np.allclose(grid.ds.Cs_w, prior_Cs_w)
-                ):
-                    raise ValueError(
-                        "The grid file contains vertical coordinates (Cs_r, Cs_w), "
-                        "but they are inconsistent with the provided theta_s, theta_b, hc, and N."
-                    )
-
-        # Case: user did not provide vertical coordinate parameters
-        elif prior_Cs_r is None or prior_Cs_w is None:
-            logging.warning("Vertical coordinates (Cs_r, Cs_w) not found in grid file.")
-
-            # Use fallback parameters
-            grid.update_vertical_coordinate(
-                N=100, theta_s=5.0, theta_b=2.0, hc=300.0, verbose=True
-            )
-
-        # Final fallback: get vertical coordinate parameters from attributes if available
-        else:
-            if not all(attr in grid.ds.attrs for attr in ["theta_s", "theta_b", "hc"]):
-                raise ValueError(
-                    "Missing vertical coordinate attributes in grid file: "
-                    "'theta_s', 'theta_b', or 'hc'."
-                )
-
-        # Assign vertical coordinate metadata
-        grid.theta_s = grid.ds.attrs["theta_s"].item()
-        grid.theta_b = grid.ds.attrs["theta_b"].item()
-        grid.hc = grid.ds.attrs["hc"].item()
-        grid.N = len(grid.ds.s_rho)
-
-        # Manually set the remaining attributes by extracting parameters from dataset
-        grid.nx = ds.sizes["xi_rho"] - 2
-        grid.ny = ds.sizes["eta_rho"] - 2
-        if "center_lon" in ds.attrs:
-            center_lon = float(ds.attrs["center_lon"])
-        elif "tra_lon" in ds:
-            center_lon = float(extract_single_value(ds["tra_lon"]))
-        elif "title" in ds.attrs:
-            match = re.search(r"Lon:\s*(-?\d+(?:\.\d+)?)", ds.attrs["title"])
-            if match:
-                center_lon = float(match.group(1))
-            else:
-                raise ValueError(
-                    "Could not extract 'center_lon' from title attribute. "
-                    "Expected format: '... Lon: <value> ...'"
-                )
-        else:
-            raise ValueError(
-                "Missing grid information: 'center_lon' attribute, 'tra_lon' variable, or 'Lon:' in 'title' attribute "
-                "must be present in the dataset."
-            )
-        grid.center_lon = center_lon
-        if "center_lat" in ds.attrs:
-            center_lat = float(ds.attrs["center_lat"])
-        elif "tra_lat" in ds:
-            center_lat = float(extract_single_value(ds["tra_lat"]))
-        elif "title" in ds.attrs:
-            match = re.search(r"Lat:\s*(-?\d+(?:\.\d+)?)", ds.attrs["title"])
-            if match:
-                center_lat = float(match.group(1))
-            else:
-                raise ValueError(
-                    "Could not extract 'center_lat' from title attribute. "
-                    "Expected format: '... Lon: <value> ...'"
-                )
-        else:
-            raise ValueError(
-                "Missing grid information: 'center_lat' attribute, 'tra_lat' variable, or 'Lat:' in 'title' attribute "
-                "must be present in the dataset."
-            )
-        grid.center_lat = center_lat
-        if "rot" in ds.attrs:
-            rot = float(ds.attrs["rot"])
-        elif "rotate" in ds:
-            rot = float(extract_single_value(ds["rotate"]))
-        elif "title" in ds.attrs:
-            match = re.search(r"rotate:\s*(-?\d+(?:\.\d+)?)", ds.attrs["title"])
-            if match:
-                rot = float(match.group(1))
-            else:
-                raise ValueError(
-                    "Could not extract 'rot' from title attribute. "
-                    "Expected format: '... rotate: <value> ...'"
-                )
-        else:
-            raise ValueError(
-                "Missing grid information: 'rot' attribute, 'rotate' variable, or 'rotate:' in 'title' attribute "
-                "must be present in the dataset."
-            )
-        grid.rot = rot
-
-        for attr in [
-            "size_x",
-            "size_y",
-            "hmin",
-        ]:
-            if attr in ds.attrs:
-                a = float(ds.attrs[attr])
-            else:
-                a = None
-
-            object.__setattr__(grid, attr, a)
-
-        if "topography_source_name" in ds.attrs:
-            if "topography_source_path" in ds.attrs:
-                a = {
-                    "name": ds.attrs["topography_source_name"],
-                    "path": ds.attrs["topography_source_path"],
-                }
-            else:
-                a = {"name": ds.attrs["topography_source_name"]}
-        else:
-            a = None
-
-        object.__setattr__(grid, "topography_source", a)
-
-        return grid
-
     def to_yaml(self, filepath: str | Path) -> None:
         """Export the parameters of the class to a YAML file, including the version of
         roms-tools.
@@ -1212,6 +991,284 @@ class Grid:
         z_centers = np.round(z_centers, 2)
 
         return z_centers, z_faces
+
+
+@dataclass(kw_only=True)
+class Grid(BaseGrid):
+    """A single ROMS grid, used for creating, plotting, and then saving a new ROMS
+    domain grid.
+
+    The grid generation consists of four steps:
+
+    1.  Creating the horizontal grid
+    2.  Creating the mask
+    3.  Generating the topography
+    4.  Preparing the vertical coordinate system
+
+    Parameters
+    ----------
+    nx : int
+        Number of grid points in the x-direction.
+    ny : int
+        Number of grid points in the y-direction.
+    size_x : float
+        Domain size in the x-direction (in kilometers).
+    size_y : float
+        Domain size in the y-direction (in kilometers).
+    center_lon : float
+        Longitude of grid center.
+    center_lat : float
+        Latitude of grid center.
+    rot : float, optional
+        Rotation of grid x-direction from lines of constant latitude, measured in degrees.
+        Positive values represent a counterclockwise rotation.
+        The default is 0, which means that the x-direction of the grid is aligned with lines of constant latitude.
+    topography_source : Dict[str, Union[str, Path]], optional
+        Dictionary specifying the source of the topography data:
+
+        - "name" (str): The name of the topography data source (e.g., "SRTM15").
+        - "path" (Union[str, Path, List[Union[str, Path]]]): The path to the raw data file. Can be a string or a Path object.
+
+        The default is "ETOPO5", which does not require a path.
+    hmin : float, optional
+       The minimum ocean depth (in meters). The default is 5.0.
+    N : int, optional
+        The number of vertical levels. The default is 100.
+    theta_s : float, optional
+        The surface control parameter. Must satisfy 0 < theta_s <= 10. The default is 5.0.
+    theta_b : float, optional
+        The bottom control parameter. Must satisfy 0 < theta_b <= 10. The default is 2.0.
+    hc : float, optional
+        The critical depth (in meters). The default is 300.0.
+    verbose: bool, optional
+        Indicates whether to print grid generation steps with timing. Defaults to False.
+
+    Raises
+    ------
+    ValueError
+        If you try to create a grid with domain size larger than 25000 km.
+    """
+
+    @classmethod
+    def from_file(
+        cls,
+        filepath: str | Path,
+        theta_s: float | None = None,
+        theta_b: float | None = None,
+        hc: float | None = None,
+        N: int | None = None,
+        verbose: bool = False,
+    ) -> "Grid":
+        """Create a Grid instance from an existing file.
+
+        Parameters
+        ----------
+        filepath : Union[str, Path]
+            Path to the file containing the grid information.
+        theta_s : float, optional
+            Surface stretching parameter for vertical coordinate.
+        theta_b : float, optional
+            Bottom stretching parameter for vertical coordinate.
+        hc : float, optional
+            Critical depth for vertical coordinate.
+        N : int, optional
+            Number of vertical levels for vertical coordinate.
+        verbose: bool, optional
+            Indicates whether to print grid generation steps with timing. Defaults to False.
+
+        Returns
+        -------
+        Grid
+            A new instance of Grid populated with data from the file.
+        """
+        # Validate that either all or none of the vertical grid parameters are provided
+        user_params = [theta_s, theta_b, hc, N]
+        num_provided = sum(p is not None for p in user_params)
+        if 0 < num_provided < 4:
+            raise ValueError(
+                "If specifying vertical coordinate parameters, you must provide all of: "
+                "theta_s, theta_b, hc, and N."
+            )
+
+        # Load the dataset from the file
+        ds = xr.open_dataset(filepath)
+
+        if not all(mask in ds for mask in ["mask_u", "mask_v"]):
+            ds = _add_velocity_masks(ds)
+
+        # Create a new Grid instance without calling __init__ and __post_init__
+        grid = cls.__new__(cls)
+
+        # Set the dataset for the grid instance
+        grid.ds = ds
+
+        # Check if the Greenwich meridian goes through the domain.
+        grid._straddle()
+
+        if not all(coord in grid.ds for coord in ["lat_u", "lon_u", "lat_v", "lon_v"]):
+            ds = _add_lat_lon_at_velocity_points(grid.ds, grid.straddle)
+            grid.ds = ds
+
+        # Coarsen the grid if necessary
+        if not all(
+            var in grid.ds
+            for var in [
+                "lon_coarse",
+                "lat_coarse",
+                "angle_coarse",
+                "mask_coarse",
+            ]
+        ):
+            grid._coarsen()
+
+        # Move variables to coordinates if necessary
+        for var in ["lat_rho", "lon_rho", "lat_coarse", "lon_coarse"]:
+            if var not in ds.coords:
+                ds = grid.ds.set_coords(var)
+                grid.ds = ds
+
+        # Check if vertical coordinates already exist
+        if all(var in grid.ds for var in ["Cs_r", "Cs_w"]):
+            prior_Cs_r = grid.ds.Cs_r.copy(deep=True)
+            prior_Cs_w = grid.ds.Cs_w.copy(deep=True)
+        else:
+            prior_Cs_r = None
+            prior_Cs_w = None
+
+        # Case: user provides all vertical coordinate parameters
+        if num_provided == 4:
+            grid.update_vertical_coordinate(
+                N=N, theta_s=theta_s, theta_b=theta_b, hc=hc, verbose=True
+            )
+
+            if prior_Cs_r is not None and prior_Cs_w is not None:
+                # Check for consistency between provided and file-stored vertical coordinates
+                if (grid.ds.Cs_r.shape != prior_Cs_r.shape) or (
+                    grid.ds.Cs_w.shape != prior_Cs_w.shape
+                ):
+                    raise ValueError(
+                        "The grid file contains vertical coordinates (Cs_r, Cs_w), but their shapes "
+                        "are inconsistent with the provided N."
+                    )
+                if not (
+                    np.allclose(grid.ds.Cs_r, prior_Cs_r)
+                    and np.allclose(grid.ds.Cs_w, prior_Cs_w)
+                ):
+                    raise ValueError(
+                        "The grid file contains vertical coordinates (Cs_r, Cs_w), "
+                        "but they are inconsistent with the provided theta_s, theta_b, hc, and N."
+                    )
+
+        # Case: user did not provide vertical coordinate parameters
+        elif prior_Cs_r is None or prior_Cs_w is None:
+            logging.warning("Vertical coordinates (Cs_r, Cs_w) not found in grid file.")
+
+            # Use fallback parameters
+            grid.update_vertical_coordinate(
+                N=100, theta_s=5.0, theta_b=2.0, hc=300.0, verbose=True
+            )
+
+        # Final fallback: get vertical coordinate parameters from attributes if available
+        else:
+            if not all(attr in grid.ds.attrs for attr in ["theta_s", "theta_b", "hc"]):
+                raise ValueError(
+                    "Missing vertical coordinate attributes in grid file: "
+                    "'theta_s', 'theta_b', or 'hc'."
+                )
+
+        # Assign vertical coordinate metadata
+        grid.theta_s = grid.ds.attrs["theta_s"].item()
+        grid.theta_b = grid.ds.attrs["theta_b"].item()
+        grid.hc = grid.ds.attrs["hc"].item()
+        grid.N = len(grid.ds.s_rho)
+
+        # Manually set the remaining attributes by extracting parameters from dataset
+        grid.nx = ds.sizes["xi_rho"] - 2
+        grid.ny = ds.sizes["eta_rho"] - 2
+        if "center_lon" in ds.attrs:
+            center_lon = float(ds.attrs["center_lon"])
+        elif "tra_lon" in ds:
+            center_lon = float(extract_single_value(ds["tra_lon"]))
+        elif "title" in ds.attrs:
+            match = re.search(r"Lon:\s*(-?\d+(?:\.\d+)?)", ds.attrs["title"])
+            if match:
+                center_lon = float(match.group(1))
+            else:
+                raise ValueError(
+                    "Could not extract 'center_lon' from title attribute. "
+                    "Expected format: '... Lon: <value> ...'"
+                )
+        else:
+            raise ValueError(
+                "Missing grid information: 'center_lon' attribute, 'tra_lon' variable, or 'Lon:' in 'title' attribute "
+                "must be present in the dataset."
+            )
+        grid.center_lon = center_lon
+        if "center_lat" in ds.attrs:
+            center_lat = float(ds.attrs["center_lat"])
+        elif "tra_lat" in ds:
+            center_lat = float(extract_single_value(ds["tra_lat"]))
+        elif "title" in ds.attrs:
+            match = re.search(r"Lat:\s*(-?\d+(?:\.\d+)?)", ds.attrs["title"])
+            if match:
+                center_lat = float(match.group(1))
+            else:
+                raise ValueError(
+                    "Could not extract 'center_lat' from title attribute. "
+                    "Expected format: '... Lon: <value> ...'"
+                )
+        else:
+            raise ValueError(
+                "Missing grid information: 'center_lat' attribute, 'tra_lat' variable, or 'Lat:' in 'title' attribute "
+                "must be present in the dataset."
+            )
+        grid.center_lat = center_lat
+        if "rot" in ds.attrs:
+            rot = float(ds.attrs["rot"])
+        elif "rotate" in ds:
+            rot = float(extract_single_value(ds["rotate"]))
+        elif "title" in ds.attrs:
+            match = re.search(r"rotate:\s*(-?\d+(?:\.\d+)?)", ds.attrs["title"])
+            if match:
+                rot = float(match.group(1))
+            else:
+                raise ValueError(
+                    "Could not extract 'rot' from title attribute. "
+                    "Expected format: '... rotate: <value> ...'"
+                )
+        else:
+            raise ValueError(
+                "Missing grid information: 'rot' attribute, 'rotate' variable, or 'rotate:' in 'title' attribute "
+                "must be present in the dataset."
+            )
+        grid.rot = rot
+
+        for attr in [
+            "size_x",
+            "size_y",
+            "hmin",
+        ]:
+            if attr in ds.attrs:
+                a = float(ds.attrs[attr])
+            else:
+                a = None
+
+            object.__setattr__(grid, attr, a)
+
+        if "topography_source_name" in ds.attrs:
+            if "topography_source_path" in ds.attrs:
+                a = {
+                    "name": ds.attrs["topography_source_name"],
+                    "path": ds.attrs["topography_source_path"],
+                }
+            else:
+                a = {"name": ds.attrs["topography_source_name"]}
+        else:
+            a = None
+
+        object.__setattr__(grid, "topography_source", a)
+
+        return grid
 
 
 def _rotate(coords, rot):

--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -29,8 +29,7 @@ from roms_tools.vertical_coordinate import compute_depth_coordinates, sigma_stre
 
 @dataclass(kw_only=True)
 class BaseGrid:
-    """A single ROMS grid, used for creating, plotting, and then saving a new ROMS
-    domain grid.
+    """Base class for grid.
 
     The grid generation consists of four steps:
 

--- a/roms_tools/setup/nesting.py
+++ b/roms_tools/setup/nesting.py
@@ -274,16 +274,6 @@ class ChildGrid(Grid):
         child_grid_ds = wrap_longitudes(child_grid_ds, straddle=False)
         return parent_grid_ds, child_grid_ds
 
-    @classmethod
-    def from_file(cls, filepath: str | Path, verbose: bool = False) -> "ChildGrid":
-        """This method is disabled in this subclass.
-
-        .. noindex::
-        """
-        raise NotImplementedError(
-            "The 'from_file' method is disabled in this subclass."
-        )
-
 
 def map_child_boundaries_onto_parent_grid_indices(
     parent_grid_ds,

--- a/roms_tools/setup/nesting.py
+++ b/roms_tools/setup/nesting.py
@@ -7,7 +7,7 @@ import numpy as np
 import xarray as xr
 from scipy.interpolate import griddata, interp1d
 
-from roms_tools import Grid
+from roms_tools import BaseGrid, Grid
 from roms_tools.plot import plot_nesting
 from roms_tools.setup.topography import _clip_depth
 from roms_tools.setup.utils import (
@@ -24,7 +24,7 @@ from roms_tools.utils import save_datasets
 
 
 @dataclass(kw_only=True)
-class ChildGrid(Grid):
+class ChildGrid(BaseGrid):
     """Represents a ROMS child grid that is compatible with the provided parent grid.
 
     This class establishes the relationship between a parent grid and a child grid in ROMS simulations.

--- a/roms_tools/setup/nesting.py
+++ b/roms_tools/setup/nesting.py
@@ -7,8 +7,8 @@ import numpy as np
 import xarray as xr
 from scipy.interpolate import griddata, interp1d
 
-from roms_tools import BaseGrid, Grid
 from roms_tools.plot import plot_nesting
+from roms_tools.setup.grid import BaseGrid, Grid
 from roms_tools.setup.topography import _clip_depth
 from roms_tools.setup.utils import (
     from_yaml,

--- a/roms_tools/tests/test_setup/test_nesting.py
+++ b/roms_tools/tests/test_setup/test_nesting.py
@@ -444,14 +444,6 @@ class TestNesting:
                 # Clean up the .nc file
                 filepath.unlink()
 
-    def test_disabled_from_file_method(self):
-        """Test that parent from_file method is indeed disabled."""
-        with pytest.raises(
-            NotImplementedError,
-            match="The 'from_file' method is disabled in this subclass.",
-        ):
-            ChildGrid.from_file(filepath="some_file.nc")
-
     def test_roundtrip_yaml(self, child_grid, tmp_path):
         """Test that creating a ChildGrid object, saving its parameters to yaml file,
         and re-opening yaml file creates the same object.


### PR DESCRIPTION
This PR provides a cleaner and more maintainable solution to the issue that `ChildGrid` inherits from `Grid`, despite not needing or supporting the `.from_file()` method.

To resolve this, a new `BaseGrid` class is introduced to contain all shared methods and attributes. Both `Grid` and `ChildGrid` now inherit from `BaseGrid`, with any class-specific methods, such as `.from_file()`, defined only in the appropriate subclass.


- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in `docs/api.rst`
- [ ] New functionality has documentation
