### PR TITLE
ROMS-415: Pin xarray version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "xarray >=2022.6.0",
+    "xarray>=2022.6.0,<2025.8.0",
     "numpy>2.0,<2.3",
     "pooch",
     "matplotlib",


### PR DESCRIPTION
This PR includes a temporary fix for test failures when installing `xarray==2025.8.0`

Workaround for issue #415 

- [x] Passes `pre-commit run --all-files`
