### PR TITLE
Suppress OpenMP info messages in Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,10 +10,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-22.9"
-  jobs:
-    pre_build:
-      - echo "OMP_DISPLAY_ENV=FALSE" >> $READTHEDOCS_ENV
-      - echo "OMP_DISPLAY_AFFINITY=FALSE" >> $READTHEDOCS_ENV
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,9 +10,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-22.9"
-  environment:
-    OMP_DISPLAY_ENV: "FALSE"
-    OMP_DISPLAY_AFFINITY: "FALSE"
+
+# Global environment variables for the build
+environment:
+  OMP_DISPLAY_ENV: "FALSE"
+  OMP_DISPLAY_AFFINITY: "FALSE"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-22.9"
+  environment:
+    OMP_DISPLAY_ENV: "FALSE"
+    OMP_DISPLAY_AFFINITY: "FALSE"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,11 +10,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-22.9"
-
-# Global environment variables for the build
-environment:
-  OMP_DISPLAY_ENV: "FALSE"
-  OMP_DISPLAY_AFFINITY: "FALSE"
+  jobs:
+    pre_build:
+      - echo "OMP_DISPLAY_ENV=FALSE" >> $READTHEDOCS_ENV
+      - echo "OMP_DISPLAY_AFFINITY=FALSE" >> $READTHEDOCS_ENV
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,8 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../"))
+os.environ["OMP_DISPLAY_ENV"] = "FALSE"
+os.environ["OMP_DISPLAY_AFFINITY"] = "FALSE"
 
 project = "ROMS-Tools"
 copyright = "2024, ROMS-Tools developers"


### PR DESCRIPTION
### Summary

This PR updates the `.readthedocs.yaml` configuration to suppress verbose OpenMP runtime info messages during documentation builds, such as:

```
OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.
```

These messages clutter the Read the Docs logs but do not affect functionality.