### PR TITLE
CSD-254: Skip ERA5 integration test

### DIFF
--- a/roms_tools/tests/test_setup/test_surface_forcing.py
+++ b/roms_tools/tests/test_setup/test_surface_forcing.py
@@ -902,6 +902,7 @@ def test_from_yaml_missing_surface_forcing(tmp_path, use_dask):
         yaml_filepath.unlink()
 
 
+@pytest.mark.skip("Temporary skip until memory consumption issue is addressed. # TODO")
 @pytest.mark.stream
 @pytest.mark.use_dask
 def test_surface_forcing_arco(surface_forcing_arco, tmp_path):


### PR DESCRIPTION
This change introduces a temporary workaround to a test case that is consuming all available runner memory.

-  Apply `pytest.mark.skip` to `test_surface_forcing_arco`

A follow-up ticket (CSD-254) has already been created to track the fix for the underlying issue.

### Checklist

- [x] Passes `pre-commit run --all-files`
