### PR TITLE
CSD-254: Skip ERA5 integration test

### DIFF
--- a/roms_tools/tests/test_setup/test_datasets.py
+++ b/roms_tools/tests/test_setup/test_datasets.py
@@ -456,6 +456,7 @@ def test_default_era5_dataset_loading_without_dask() -> None:
         )
 
 
+@pytest.mark.skip("Temporary skip until memory consumption issue is addressed. # TODO")
 @pytest.mark.stream
 @pytest.mark.use_dask
 @pytest.mark.use_gcsfs

--- a/roms_tools/tests/test_setup/test_surface_forcing.py
+++ b/roms_tools/tests/test_setup/test_surface_forcing.py
@@ -902,6 +902,7 @@ def test_from_yaml_missing_surface_forcing(tmp_path, use_dask):
         yaml_filepath.unlink()
 
 
+@pytest.mark.skip("Temporary skip until memory consumption issue is addressed. # TODO")
 @pytest.mark.stream
 @pytest.mark.use_dask
 def test_surface_forcing_arco(surface_forcing_arco, tmp_path):

--- a/roms_tools/tests/test_setup/test_surface_forcing.py
+++ b/roms_tools/tests/test_setup/test_surface_forcing.py
@@ -936,6 +936,7 @@ def test_surface_forcing_arco(surface_forcing_arco, tmp_path):
     Path(expected_filepath2).unlink()
 
 
+@pytest.mark.skip("Temporary skip until memory consumption issue is addressed. # TODO")
 @pytest.mark.stream
 @pytest.mark.use_dask
 @pytest.mark.use_gcsfs


### PR DESCRIPTION
This change introduces a temporary workaround to a set of test cases that consume all available runner memory.

- Apply `pytest.mark.skip` to `test_surface_forcing.test_surface_forcing_arco`
- Apply `pytest.mark.skip` to `test_surface_forcing.test_default_era5_dataset_loading`
- Apply `pytest.mark.skip` to `test_datasets.test_default_era5_dataset_loading`

A follow-up ticket (CSD-254) has already been created to track the fix for the underlying issue.

### Checklist

- [x] Passes `pre-commit run --all-files`
