### PR TITLE
Skip streaming tests on forks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,6 +82,7 @@ jobs:
   test-with-streaming:
     name: 3.13-build-with-streaming
     runs-on: ubuntu-latest
+    if: github.repository == github.repository_owner # Only run on the main repo, skip forks
     strategy:
       matrix:
         python-version: ["3.13"]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,7 +82,7 @@ jobs:
   test-with-streaming:
     name: 3.13-build-with-streaming
     runs-on: ubuntu-latest
-    if: github.repository == github.repository_owner # Only run on the main repo, skip forks
+    if: github.repository == github.event.pull_request.head.repo.full_name
     strategy:
       matrix:
         python-version: ["3.13"]


### PR DESCRIPTION
... because we don't have the `copernicusmarine` secrets on forks, which is why the streaming tests fail there.