### PR TITLE
Skip Codecov uploads on forks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -216,7 +216,7 @@ jobs:
 
 
   test-glorys-regional-invariance:
-    name: ${{ matrix.python-version }}-build-glorys-regional-invariance
+    name: 3.13-build-glorys-regional-invariance
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,7 +51,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: github.repository == 'CWorthy-ocean/roms-tools'
+        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: github.repository == 'CWorthy-ocean/roms-tools'
+        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: github.repository == 'CWorthy-ocean/roms-tools'
+        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -209,7 +209,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: github.repository == 'CWorthy-ocean/roms-tools'
+        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -266,7 +266,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: github.repository == 'CWorthy-ocean/roms-tools'
+        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
+        if: github.repository == 'CWorthy-ocean/roms-tools'
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -101,6 +102,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
+        if: github.repository == 'CWorthy-ocean/roms-tools'
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -156,6 +158,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
+        if: github.repository == 'CWorthy-ocean/roms-tools'
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -206,6 +209,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
+        if: github.repository == 'CWorthy-ocean/roms-tools'
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -262,6 +266,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
+        if: github.repository == 'CWorthy-ocean/roms-tools'
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,14 +51,13 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: without-dask
           name: without-dask-py${{ matrix.python-version }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   test-with-dask:
     name: 3.13-build-with-dask
@@ -102,14 +101,13 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: with-dask
           name: with-dask-py${{ matrix.python-version }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   test-with-streaming:
     name: 3.13-build-with-streaming
@@ -158,14 +156,13 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: with-streaming
           name: with-streaming
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   test-with-dask-and-xesmf:
     name: 3.13-build-with-dask-and-xesmf
@@ -209,14 +206,13 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: with-dask-and-xesmf
           name: with-dask-and-xesmf
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
 
   test-glorys-regional-invariance:
@@ -266,11 +262,10 @@ jobs:
           coverage xml
 
       - name: Upload coverage reports to Codecov
-        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: glorys-regional-invariance
           name: glorys-regional-invariance
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -218,6 +218,7 @@ jobs:
   test-glorys-regional-invariance:
     name: ${{ matrix.python-version }}-build-glorys-regional-invariance
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false
     strategy:
       matrix:
         python-version: ["3.13"]


### PR DESCRIPTION
When opening a PR from a fork, the CI fails due to GitHub not passing repository secrets (like `CODECOV_TOKEN`) to workflows running in forks.
```
error - Commit creating failed: {"message":"Token required because branch is protected"}
```
This PR fixes this issue by skipping Codecov uploads on forks.