### PR TITLE
adding emod dataset as a class

### DIFF
--- a/roms_tools/datasets/download.py
+++ b/roms_tools/datasets/download.py
@@ -90,6 +90,7 @@ pup_test_data = pooch.create(
         "GSHHS_l_L1.prj": "98aaf3d1c0ecadf1a424a4536de261c3daf4e373697cb86c40c43b989daf52eb",
         "GSHHS_l_L1.shp": "bc76f101f9b8671f90e734b4026da91c20066fc627cc8b5889ba22d90cbf97e9",
         "GSHHS_l_L1.shx": "72879354892d80d6c39c612f645661ec0edc75f3f9f8f74b19d9387ae0327377",
+        "EMODnet_C2_coarse100.nc": "4202a6a5877de726bf13f41de7a1edfea2db83278ce371fe7732eb4b6770ed6d",
     },
 )
 

--- a/roms_tools/datasets/lat_lon_datasets.py
+++ b/roms_tools/datasets/lat_lon_datasets.py
@@ -660,7 +660,7 @@ class LatLonDataset:
         """
         if "depth" in self.dim_names:
             self.ds = extrapolate_deepest_to_bottom(self.ds, self.dim_names["depth"])
-            
+
     @classmethod
     def from_ds(cls, original_dataset: LatLonDataset, ds: xr.Dataset) -> LatLonDataset:
         """Substitute the internal dataset of a LatLonDataset object with a new xarray
@@ -1691,12 +1691,13 @@ class SRTM15Dataset(LatLonDataset):
         default_factory=lambda: {"longitude": "lon", "latitude": "lat"}
     )
 
+
 @dataclass(kw_only=True)
 class EMODDataset(LatLonDataset):
     """Represents topography data on the original grid from the SRTM15 dataset."""
 
     translate_lon_to_360: bool = True
-    
+
     var_names: dict[str, str] = field(
         default_factory=lambda: {
             "topo": "elevation",
@@ -1705,6 +1706,7 @@ class EMODDataset(LatLonDataset):
     dim_names: dict[str, str] = field(
         default_factory=lambda: {"longitude": "lon", "latitude": "lat"}
     )
+
 
 @dataclass
 class TPXOManager:

--- a/roms_tools/datasets/lat_lon_datasets.py
+++ b/roms_tools/datasets/lat_lon_datasets.py
@@ -1708,6 +1708,16 @@ class EMODDataset(LatLonDataset):
     )
     needs_lateral_fill: bool = True
 
+    def post_process(self) -> None:
+        """Assign land mask."""
+        mask = xr.where(
+            self.ds[self.var_names["topo"]].isnull(),
+            0,
+            1,
+        )
+
+        self.ds["mask"] = mask
+
 
 @dataclass
 class TPXOManager:

--- a/roms_tools/datasets/lat_lon_datasets.py
+++ b/roms_tools/datasets/lat_lon_datasets.py
@@ -660,7 +660,7 @@ class LatLonDataset:
         """
         if "depth" in self.dim_names:
             self.ds = extrapolate_deepest_to_bottom(self.ds, self.dim_names["depth"])
-
+            
     @classmethod
     def from_ds(cls, original_dataset: LatLonDataset, ds: xr.Dataset) -> LatLonDataset:
         """Substitute the internal dataset of a LatLonDataset object with a new xarray
@@ -1691,6 +1691,20 @@ class SRTM15Dataset(LatLonDataset):
         default_factory=lambda: {"longitude": "lon", "latitude": "lat"}
     )
 
+@dataclass(kw_only=True)
+class EMODDataset(LatLonDataset):
+    """Represents topography data on the original grid from the SRTM15 dataset."""
+
+    translate_lon_to_360: bool = True
+    
+    var_names: dict[str, str] = field(
+        default_factory=lambda: {
+            "topo": "elevation",
+        }
+    )
+    dim_names: dict[str, str] = field(
+        default_factory=lambda: {"longitude": "lon", "latitude": "lat"}
+    )
 
 @dataclass
 class TPXOManager:

--- a/roms_tools/datasets/lat_lon_datasets.py
+++ b/roms_tools/datasets/lat_lon_datasets.py
@@ -131,11 +131,11 @@ class LatLonDataset:
     var_names: dict[str, str]
     opt_var_names: dict[str, str] = field(default_factory=dict)
     climatology: bool = False
-    needs_lateral_fill: bool | None = True
+    needs_lateral_fill: bool = True
     use_dask: bool = False
     read_zarr: bool = False
     allow_flex_time: bool = False
-    apply_post_processing: bool | None = True
+    apply_post_processing: bool = True
 
     ds_loader_fn: Callable[[], xr.Dataset] | None = None
     is_global: bool = field(init=False, repr=False)
@@ -1089,7 +1089,7 @@ class UnifiedDataset(LatLonDataset):
     attribute is set to `False`.
     """
 
-    needs_lateral_fill: bool | None = False
+    needs_lateral_fill: bool = False
 
     # overwrite clean_up method from parent class
     def clean_up(self, ds: xr.Dataset) -> xr.Dataset:
@@ -1655,6 +1655,7 @@ class ETOPO5Dataset(LatLonDataset):
     dim_names: dict[str, str] = field(
         default_factory=lambda: {"longitude": "lon", "latitude": "lat"}
     )
+    needs_lateral_fill: bool = False
 
     def clean_up(self, ds: xr.Dataset) -> xr.Dataset:
         """Assign lat and lon as coordinates.
@@ -1690,13 +1691,12 @@ class SRTM15Dataset(LatLonDataset):
     dim_names: dict[str, str] = field(
         default_factory=lambda: {"longitude": "lon", "latitude": "lat"}
     )
+    needs_lateral_fill: bool = False
 
 
 @dataclass(kw_only=True)
 class EMODDataset(LatLonDataset):
-    """Represents topography data on the original grid from the SRTM15 dataset."""
-
-    translate_lon_to_360: bool = True
+    """Represents topography data on the original grid from the EMOD dataset."""
 
     var_names: dict[str, str] = field(
         default_factory=lambda: {
@@ -1706,6 +1706,7 @@ class EMODDataset(LatLonDataset):
     dim_names: dict[str, str] = field(
         default_factory=lambda: {"longitude": "lon", "latitude": "lat"}
     )
+    needs_lateral_fill: bool = True
 
 
 @dataclass
@@ -2433,6 +2434,7 @@ def choose_subdomain(
                 if lon_min - margin < 0:
                     lon_min += 360
                     lon_max += 360
+
     # Select the subdomain in longitude direction
     subdomain = subdomain.sel(
         **{

--- a/roms_tools/setup/topography.py
+++ b/roms_tools/setup/topography.py
@@ -7,7 +7,7 @@ import gcm_filters
 import numpy as np
 import xarray as xr
 
-from roms_tools.datasets.lat_lon_datasets import ETOPO5Dataset, SRTM15Dataset
+from roms_tools.datasets.lat_lon_datasets import ETOPO5Dataset, SRTM15Dataset, EMODDataset
 from roms_tools.regrid import LateralRegridToROMS
 from roms_tools.setup.utils import handle_boundaries
 
@@ -115,9 +115,12 @@ def _get_topography_data(source):
     elif source["name"] == "SRTM15":
         kwargs["filename"] = source["path"]
         data = SRTM15Dataset(**kwargs)
+    elif source["name"] == "EMOD":
+        kwargs["filename"] = source["path"]
+        data = EMODDataset(**kwargs)
     else:
         raise ValueError(
-            'Only "ETOPO5" and "SRTM15" are valid options for topography_source["name"].'
+            'Only "ETOPO5", "SRTM15" and "EMOD" are valid options for topography_source["name"].'
         )
 
     return data

--- a/roms_tools/setup/topography.py
+++ b/roms_tools/setup/topography.py
@@ -7,7 +7,11 @@ import gcm_filters
 import numpy as np
 import xarray as xr
 
-from roms_tools.datasets.lat_lon_datasets import ETOPO5Dataset, SRTM15Dataset, EMODDataset
+from roms_tools.datasets.lat_lon_datasets import (
+    EMODDataset,
+    ETOPO5Dataset,
+    SRTM15Dataset,
+)
 from roms_tools.regrid import LateralRegridToROMS
 from roms_tools.setup.utils import handle_boundaries
 

--- a/roms_tools/setup/topography.py
+++ b/roms_tools/setup/topography.py
@@ -154,6 +154,7 @@ def _make_raw_topography(
     data.choose_subdomain(target_coords, buffer_points=3, verbose=verbose)
     # Enforce double precision to ensure reproducibility
     data.convert_to_float64()
+    data.apply_lateral_fill()
 
     if verbose:
         start_time = time.time()

--- a/roms_tools/tests/test_setup/test_grid.py
+++ b/roms_tools/tests/test_setup/test_grid.py
@@ -122,6 +122,25 @@ def grid_that_straddles_180_degree_meridian_with_global_srtm15_data():
 
 
 @pytest.fixture()
+def grid_with_emod_data():
+    grid = Grid(
+        nx=2,
+        ny=2,
+        size_x=32,
+        size_y=19.2,
+        center_lon=-21.68,
+        center_lat=64.325,
+        rot=0,
+        topography_source={
+            "name": "EMOD",
+            "path": download_test_data("EMODnet_C2_coarse100.nc"),
+        },
+    )
+
+    return grid
+
+
+@pytest.fixture()
 def grid_with_gshhs_coastlines():
     iceland_fjord_kwargs = {
         "nx": 80,
@@ -203,6 +222,7 @@ def test_coords_relation(grid_fixture, request):
         "grid_that_straddles_dateline_with_global_srtm15_data",
         "grid_that_straddles_180_degree_meridian_with_global_srtm15_data",
         "grid_with_gshhs_coastlines",
+        "grid_with_emod_data",
     ],
 )
 def test_successful_initialization_with_topography(grid_fixture, request):
@@ -344,6 +364,7 @@ def test_grid_straddle_crosses_meridian():
         "grid_that_straddles_dateline_with_shifted_global_etopo_data",
         "grid_that_straddles_dateline_with_global_srtm15_data",
         "grid_with_gshhs_coastlines",
+        "grid_with_emod_data",
     ],
 )
 def test_roundtrip_netcdf(grid_fixture, tmp_path, request):
@@ -379,6 +400,7 @@ def test_roundtrip_netcdf(grid_fixture, tmp_path, request):
         "grid_that_straddles_dateline_with_shifted_global_etopo_data",
         "grid_that_straddles_dateline_with_global_srtm15_data",
         "grid_with_gshhs_coastlines",
+        "grid_with_emod_data",
     ],
 )
 def test_roundtrip_yaml(grid_fixture, tmp_path, request):
@@ -411,6 +433,7 @@ def test_roundtrip_yaml(grid_fixture, tmp_path, request):
         "grid_that_straddles_dateline_with_shifted_global_etopo_data",
         "grid_that_straddles_dateline_with_global_srtm15_data",
         "grid_with_gshhs_coastlines",
+        "grid_with_emod_data",
     ],
 )
 def test_roundtrip_from_file_yaml(grid_fixture, tmp_path, request):
@@ -441,6 +464,7 @@ def test_roundtrip_from_file_yaml(grid_fixture, tmp_path, request):
         "grid_that_straddles_dateline_with_shifted_global_etopo_data",
         "grid_that_straddles_dateline_with_global_srtm15_data",
         "grid_with_gshhs_coastlines",
+        "grid_with_emod_data",
     ],
 )
 def test_files_have_same_hash(grid_fixture, tmp_path, request):


### PR DESCRIPTION
minimum example that fails:

```python
grid = Grid(
    nx=2,
    ny=2,
    size_x=32,
    size_y=19.2,
    center_lon=-21.68,
    center_lat=64.325,
    rot=0,
    topography_source={
        "name": "EMOD",
        "path": "/anvil/projects/x-ees250129/Datasets/EMODnet_C2_coarse100.nc"},
    N=5  # number of vertical layers
)
```

error message:
```
ValueError: NaN values found in regridded topography. This likely occurs because the ROMS grid, including a small safety margin for interpolation, is not fully contained within the topography dataset's longitude[/latitude](https://ondemand.anvil.rcac.purdue.edu/latitude) range. Please ensure that the dataset covers the entire area required by the ROMS grid.
```

- [x] Closes #532
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in `docs/api.rst`
- [ ] New functionality has documentation
