### PR TITLE
add optional 'include_pressure_fluxes' key to ChildGrid metadata dict

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -305,6 +305,21 @@ def child_grid_with_bgc(big_grid):
 
 
 @pytest.fixture(scope="session")
+def child_grid_with_pflx(big_grid):
+    return ChildGrid(
+        parent_grid=big_grid,
+        nx=10,
+        ny=10,
+        center_lon=-23,
+        center_lat=61,
+        rot=-20,
+        size_x=500,
+        size_y=500,
+        metadata={"include_pressure_fluxes": True},
+    )
+
+
+@pytest.fixture(scope="session")
 def tidal_forcing(use_dask: bool) -> TidalForcing:
     grid = Grid(
         nx=3, ny=3, size_x=1500, size_y=1500, center_lon=235, center_lat=25, rot=-20

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* `ChildGrid` now supports optional baroclinic pressure fluxes via metadata ([#568](https://github.com/CWorthy-ocean/roms-tools/pull/568))
 * Include time records strictly outside start/end bounds for `SurfaceForcing`, `BoundaryForcing` ([#547](https://github.com/CWorthy-ocean/roms-tools/pull/547))
 * `ChildGrid` now infers open boundaries from the mask by default and supports optional BGC boundary outputs via metadata ([#550](https://github.com/CWorthy-ocean/roms-tools/pull/550))
 * Memory savings and speedup for vertical regridding in `InitialConditions` and `BoundaryForcing` ([#528](https://github.com/CWorthy-ocean/roms-tools/pull/528))

--- a/roms_tools/setup/nesting.py
+++ b/roms_tools/setup/nesting.py
@@ -54,6 +54,7 @@ class ChildGrid(Grid):
         - `"prefix"` (str): Prefix for variable names in `ds_nesting`. Defaults to `"child"`.
         - `"period"` (float): Temporal resolution for boundary outputs in seconds. Defaults to 3600 (hourly).
         - `"include_bgc"` (bool): Whether to include BGC variables in boundary outputs. Defaults to `False`.
+        - `"include_pressure_fluxes"` (bool): Whether to include baroclinic pressure fluxes in boundary outputs. Defaults to `False`.
     verbose: bool, optional
         Indicates whether to print grid generation steps with timing. Defaults to False.
     """
@@ -87,6 +88,7 @@ class ChildGrid(Grid):
                 "prefix": "child",
                 "period": 3600.0,
                 "include_bgc": False,
+                "include_pressure_fluxes": False,
             }
             # Merge user metadata on top of defaults
             self.metadata = {**defaults, **self.metadata}
@@ -106,6 +108,7 @@ class ChildGrid(Grid):
                 self.metadata["prefix"],
                 self.metadata["period"],
                 self.metadata["include_bgc"],
+                self.metadata["include_pressure_fluxes"],
             )
 
             self.ds_nesting = ds_nesting
@@ -390,6 +393,7 @@ def map_child_boundaries_onto_parent_grid_indices(
     prefix: str = "child",
     period: float = 3600.0,
     include_bgc: bool = False,
+    include_pressure_fluxes: bool = False,
     update_land_indices: bool = True,
 ):
     """Maps child grid boundary points onto absolute indices of the parent grid.
@@ -423,6 +427,9 @@ def map_child_boundaries_onto_parent_grid_indices(
 
     include_bgc: bool, optional
         Whether to include BGC variables in the boundary outputs.
+
+    include_pressure_fluxes: bool, optional
+        Whether to include baroclinic pressure fluxes in the boundary outputs.
 
     update_land_indices : bool, optional
         If `True`, updates indices that fall on land in the parent grid to nearby ocean points.
@@ -500,9 +507,13 @@ def map_child_boundaries_onto_parent_grid_indices(
                     ds[var_name].attrs["units"] = "non-dimensional and radian"
 
                     if grid_location == "u":
-                        ds[var_name].attrs["output_vars"] = "ubar, u, up"
+                        ds[var_name].attrs["output_vars"] = (
+                            "ubar, u, up" if include_pressure_fluxes else "ubar, u"
+                        )
                     elif grid_location == "v":
-                        ds[var_name].attrs["output_vars"] = "vbar, v, vp"
+                        ds[var_name].attrs["output_vars"] = (
+                            "vbar, v, vp" if include_pressure_fluxes else "vbar, v"
+                        )
 
                 ds[var_name].attrs["output_period"] = period
 

--- a/roms_tools/tests/test_setup/test_nesting.py
+++ b/roms_tools/tests/test_setup/test_nesting.py
@@ -364,14 +364,43 @@ class TestModifyChid:
 
 class TestNesting:
     @pytest.mark.parametrize(
-        "fixture_name, include_bgc, expected_r_vars",
+        "fixture_name, include_bgc, include_pressure_fluxes, expected_r_vars, expected_u_vars, expected_v_vars",
         [
-            ("child_grid_with_bgc", True, "zeta, temp, salt, bgc"),
-            ("child_grid_that_straddles", False, "zeta, temp, salt"),
+            (
+                "child_grid_with_bgc",
+                True,
+                False,
+                "zeta, temp, salt, bgc",
+                "ubar, u",
+                "vbar, v",
+            ),
+            (
+                "child_grid_that_straddles",
+                False,
+                False,
+                "zeta, temp, salt",
+                "ubar, u",
+                "vbar, v",
+            ),
+            (
+                "child_grid_with_pflx",
+                False,
+                True,
+                "zeta, temp, salt",
+                "ubar, u, up",
+                "vbar, v, vp",
+            ),
         ],
     )
     def test_successful_initialization(
-        self, request, fixture_name, include_bgc, expected_r_vars
+        self,
+        request,
+        fixture_name,
+        include_bgc,
+        include_pressure_fluxes,
+        expected_r_vars,
+        expected_u_vars,
+        expected_v_vars,
     ):
         child_grid = request.getfixturevalue(fixture_name)
 
@@ -399,9 +428,9 @@ class TestNesting:
                 if location == "r":
                     assert ds[varname].attrs["output_vars"] == expected_r_vars
                 elif location == "u":
-                    assert ds[varname].attrs["output_vars"] == "ubar, u, up"
+                    assert ds[varname].attrs["output_vars"] == expected_u_vars
                 elif location == "v":
-                    assert ds[varname].attrs["output_vars"] == "vbar, v, vp"
+                    assert ds[varname].attrs["output_vars"] == expected_v_vars
 
     def test_default_boundaries(self, child_grid_with_eastern_boundary_closed):
         assert child_grid_with_eastern_boundary_closed.boundaries == {


### PR DESCRIPTION
when `True`, the `edata` file includes `up` and `vp` in `output_vars`, triggering ROMS to calculate pressure fluxes and include them in `ext` files. Defaults to `False`. Was previously hardcoded `True`.

- [x] Closes #566
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
- [x] New functionality has documentation
