### PR TITLE
Ensure longitude btwn 0 to 360

### DIFF
--- a/roms_tools/setup/grid.py
+++ b/roms_tools/setup/grid.py
@@ -1058,8 +1058,7 @@ class Grid:
 
             # make sure lons are in [0, 360] range
             for lon in ["lon", "lonu", "lonv", "lonq"]:
-                coords[lon][coords[lon] < 0] = coords[lon][coords[lon] < 0] + 2 * np.pi
-                # coords[lon][coords[lon] > 2 * np.pi] = coords[lon][coords[lon] > 2 * np.pi] - 2 * np.pi
+                coords[lon] = coords[lon] % (2 * np.pi)
 
             ds = self._create_grid_ds(coords)
 

--- a/roms_tools/tests/test_setup/test_nesting.py
+++ b/roms_tools/tests/test_setup/test_nesting.py
@@ -65,6 +65,20 @@ def small_grid_that_straddles180():
     )
 
 
+@pytest.fixture()
+def small_grid_that_straddles0_large_lon():
+    return Grid(
+        nx=10, ny=10, center_lon=720, center_lat=61, rot=0, size_x=50, size_y=200
+    )
+
+
+@pytest.fixture()
+def small_grid_that_straddles0_large_negative_lon():
+    return Grid(
+        nx=10, ny=10, center_lon=-720, center_lat=61, rot=0, size_x=50, size_y=200
+    )
+
+
 @pytest.mark.parametrize(
     "parent_name,child_name,context",
     [
@@ -90,6 +104,24 @@ def test_check_child_inside_parent(request, parent_name, child_name, context):
 
     with context:
         _check_child_outside_parent(parent_grid_ds, child_grid_ds, boundaries)
+
+
+@pytest.mark.parametrize(
+    "grid",
+    [
+        "small_grid_that_straddles0_large_lon",
+        "small_grid_that_straddles0_large_negative_lon",
+    ],
+)
+def test_check_straddle_lon_range(request, grid):
+    grid = request.getfixturevalue(grid)
+
+    expected_lon_rho_min = 0.0
+    expected_lon_rho_max = 360.0
+
+    assert grid.ds["lon_rho"].min() >= expected_lon_rho_min
+    assert grid.ds["lon_rho"].max() <= expected_lon_rho_max
+    assert grid.straddle
 
 
 class TestInterpolateIndices:


### PR DESCRIPTION
When ROMS-Tools creates a Grid, it makes sure the longitude is between 0 to 360 by adding 2*pi if any value is negative. This doesn't handle `center_lon` that are well out of the normal range (-720 or 720) for example. 

`straddle` is later determined based on the difference in longitude between two consecutive points and whether that difference exceeds 300 (true when it goes from 360 to 0), but this fails to register `True`, if the center longitude (`center_lon`) is either 720 or -720 (each equivalent to 0 degrees and should register `True` for `grid.straddle`). 

With the changes added, it will ensure any longitude set will be within the range of 360 degrees. 

- [x] Passes `pre-commit run --all-files`
- [ ] Changes are documented in `docs/releases.md`
