### PR TITLE
Allow url paths

### DIFF
--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -1342,6 +1342,9 @@ def normalize_paths(value: Any) -> Any:
     Heuristic: strings containing '/' or ending with '.nc' are treated as paths.
     """
     if isinstance(value, str):
+        # if the path looks like a URL, don't make it a PosixPath, or it will strip out the double //
+        if "://" in value:
+            return value
         return Path(value) if "/" in value or value.endswith(".nc") else value
     if isinstance(value, list):
         return [normalize_paths(v) for v in value]


### PR DESCRIPTION
ROMS-Tools will reduce a double // to single when made into type `Path`. This causes a crash if the ERA5 data is to be streamed from google cloud, and the url starts with `gs://`.

- [x] Tests pass
