### PR TITLE
Renaming make_edata to make_nesting_info

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,7 +25,7 @@ from roms_tools.datasets.lat_lon_datasets import (
     UnifiedBGCDataset,
     UnifiedBGCSurfaceDataset,
 )
-from roms_tools.setup.nesting import align_grids, make_edata
+from roms_tools.setup.nesting import align_grids, make_nesting_info
 
 
 class SkippableOptions(enum.StrEnum):
@@ -316,7 +316,7 @@ def child_grid_with_bgc(big_grid):
         size_y=500,
     )
     child_grid = align_grids(big_grid, child_grid)
-    make_edata(big_grid, child_grid, include_bgc=True)
+    make_nesting_info(big_grid, child_grid, include_bgc=True)
     return child_grid
 
 
@@ -332,7 +332,7 @@ def child_grid_with_pflx(big_grid):
         size_y=500,
     )
     child_grid = align_grids(big_grid, child_grid)
-    make_edata(big_grid, child_grid, include_pressure_fluxes=True)
+    make_nesting_info(big_grid, child_grid, include_pressure_fluxes=True)
 
     return child_grid
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -78,7 +78,7 @@ Utilities
    :toctree: generated/
 
    roms_tools.setup.nesting.align_grids
-   roms_tools.setup.nesting.make_edata
+   roms_tools.setup.nesting.make_nesting_info
    roms_tools.tiling.partition.partition_netcdf
    roms_tools.tiling.join.join_netcdf
    roms_tools.plot.plot

--- a/docs/nesting.ipynb
+++ b/docs/nesting.ipynb
@@ -1160,7 +1160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "id": "14e984e8-90e1-4c1a-bdb5-c12e9734d46d",
    "metadata": {},
    "outputs": [

--- a/docs/nesting.ipynb
+++ b/docs/nesting.ipynb
@@ -1160,7 +1160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "14e984e8-90e1-4c1a-bdb5-c12e9734d46d",
    "metadata": {},
    "outputs": [

--- a/docs/nesting.ipynb
+++ b/docs/nesting.ipynb
@@ -48,7 +48,7 @@
    },
    "outputs": [],
    "source": [
-    "from roms_tools import Grid, align_grids, make_nesting_infong_info"
+    "from roms_tools import Grid, align_grids, make_nesting_info"
    ]
   },
   {
@@ -3389,7 +3389,7 @@
    "source": [
     "### Saving as NetCDF or YAML file\n",
     "\n",
-    "The `ds_nesting` is saved in the `make_edata` step above.\n",
+    "The `ds_nesting` is saved in the `make_nesting_info` step above.\n",
     "\n",
     "We can save the parent and child Grid objects as NetCDF files. The `.save` method will save the grid information itself (`.ds`) to a NetCDF file. "
    ]

--- a/docs/nesting.ipynb
+++ b/docs/nesting.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "51aebd3d-ce39-4a5e-a487-9f3ea81012b9",
    "metadata": {
     "tags": []

--- a/docs/nesting.ipynb
+++ b/docs/nesting.ipynb
@@ -41,14 +41,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "51aebd3d-ce39-4a5e-a487-9f3ea81012b9",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from roms_tools import Grid, align_grids, make_edata"
+    "from roms_tools import Grid, align_grids, make_nesting_infong_info"
    ]
   },
   {
@@ -1033,7 +1033,7 @@
    "id": "5c55d29c-5374-49bc-a700-1223757d789d",
    "metadata": {},
    "source": [
-    "Steps 1 and 2 from above are performed by the `ROMS-Tools` functions `align_grids` and `make_edata`.\n",
+    "Steps 1 and 2 from above are performed by the `ROMS-Tools` functions `align_grids` and `make_nesting_info`.\n",
     "To perform step 1, we use the `align_grids` function."
    ]
   },
@@ -1155,12 +1155,12 @@
    "id": "7fdc71b8-9b35-4a22-8dfc-7e0d9b173707",
    "metadata": {},
    "source": [
-    "The boundaries of the child grid need to be mapped onto the parent grid's indices (Step 2) so that the results from the parent grid can be passed to the child grid. To do so, we use the `make_edata` function."
+    "The boundaries of the child grid need to be mapped onto the parent grid's indices (Step 2) so that the results from the parent grid can be passed to the child grid. To do so, we use the `make_nesting_info` function."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "14e984e8-90e1-4c1a-bdb5-c12e9734d46d",
    "metadata": {},
    "outputs": [
@@ -1184,7 +1184,7 @@
     "include_pressure_fluxes = False\n",
     "\n",
     "filepath = '/anvil/scratch/x-smaticka/sims_runtime/nesting/nesting_info.nc' \n",
-    "ds_nesting = make_edata(parent_grid=parent_grid, child_grid=child_grid, filepath=filepath, prefix=prefix, period=period, include_bgc=include_bgc, include_pressure_fluxes=include_pressure_fluxes, verbose=True)"
+    "ds_nesting = make_nesting_info(parent_grid=parent_grid, child_grid=child_grid, filepath=filepath, prefix=prefix, period=period, include_bgc=include_bgc, include_pressure_fluxes=include_pressure_fluxes, verbose=True)"
    ]
   },
   {
@@ -1192,7 +1192,7 @@
    "id": "5534b9c6-7ac6-451a-9674-08660d309b4f",
    "metadata": {},
    "source": [
-    "The indexed boundaries are now stored in an `xarray.Dataset` accessible via the `ds_nesting` dataset, they are also saved to the `filepath` prescribed. If it is not desired to save a file, `filepath` can be set to `None` in `make_edata`."
+    "The indexed boundaries are now stored in an `xarray.Dataset` accessible via the `ds_nesting` dataset, they are also saved to the `filepath` prescribed. If it is not desired to save a file, `filepath` can be set to `None` in `make_nesting_info`."
    ]
   },
   {
@@ -1200,7 +1200,7 @@
    "id": "48583ed4-2485-4357-b0cd-ccf6b0f1b50a",
    "metadata": {},
    "source": [
-    "Notice that the `make_edata` function requires a few parameters in addition to the parent and child grids:\n",
+    "Notice that the `make_nesting_info` function requires a few parameters in addition to the parent and child grids:\n",
     "\n",
     "* `boundaries`: Specifies which of the child grid’s boundaries are open (`south`, `east`, `north`, `west`). **NOTE:** If omitted, `ROMS-Tools` will automatically infer them based on the land/sea mask. This affects two aspects:\n",
     "  * The specified boundaries are adjusted to match the parent grid’s topography and mask.\n",
@@ -2283,7 +2283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "3cc07f70-829f-4944-95a6-cd235f4be5e6",
    "metadata": {},
    "outputs": [
@@ -2307,7 +2307,7 @@
     "include_pressure_fluxes = True\n",
     "\n",
     "filepath = '/anvil/scratch/x-smaticka/sims_runtime/nesting/nesting_info_with_bgc.nc' \n",
-    "ds_nesting_with_bgc_and_pflx = make_edata(parent_grid=parent_grid, child_grid=child_grid, filepath=filepath, prefix=prefix, period=period, include_bgc=include_bgc, include_pressure_fluxes=include_pressure_fluxes, verbose=True)"
+    "ds_nesting_with_bgc_and_pflx = make_nesting_info(parent_grid=parent_grid, child_grid=child_grid, filepath=filepath, prefix=prefix, period=period, include_bgc=include_bgc, include_pressure_fluxes=include_pressure_fluxes, verbose=True)"
    ]
   },
   {

--- a/docs/nesting.ipynb
+++ b/docs/nesting.ipynb
@@ -2283,7 +2283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "3cc07f70-829f-4944-95a6-cd235f4be5e6",
    "metadata": {},
    "outputs": [

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,7 @@
 
 ### New Features
 
+* `make_edata` changed to `make_nesting_info`
 * `to_yaml` and `from_yaml` were adjusted to handle child grids after they've been modified ([#573](https://github.com/CWorthy-ocean/roms-tools/pull/573))
 * Nesting now supports optional baroclinic pressure fluxes via metadata ([#568](https://github.com/CWorthy-ocean/roms-tools/pull/568))
 * Include time records strictly outside start/end bounds for `SurfaceForcing`, `BoundaryForcing` ([#547](https://github.com/CWorthy-ocean/roms-tools/pull/547))

--- a/roms_tools/__init__.py
+++ b/roms_tools/__init__.py
@@ -15,7 +15,7 @@ from roms_tools.setup.boundary_forcing import BoundaryForcing  # noqa: F401
 from roms_tools.setup.cdr_forcing import CDRForcing  # noqa: F401
 from roms_tools.setup.cdr_release import TracerPerturbation, VolumeRelease  # noqa: F401
 from roms_tools.setup.initial_conditions import InitialConditions  # noqa: F401
-from roms_tools.setup.nesting import align_grids, make_edata  # noqa: F401
+from roms_tools.setup.nesting import align_grids, make_nesting_info  # noqa: F401
 from roms_tools.plot import plot_nesting  # noqa: F401
 from roms_tools.setup.river_forcing import RiverForcing  # noqa: F401
 from roms_tools.setup.surface_forcing import SurfaceForcing  # noqa: F401

--- a/roms_tools/setup/nesting.py
+++ b/roms_tools/setup/nesting.py
@@ -98,7 +98,7 @@ def align_grids(
     return child_grid
 
 
-def make_edata(
+def make_nesting_info(
     parent_grid: Grid,
     child_grid: Grid,
     filepath: str | None = None,

--- a/roms_tools/tests/test_setup/test_nesting.py
+++ b/roms_tools/tests/test_setup/test_nesting.py
@@ -16,7 +16,7 @@ from roms_tools.setup.nesting import (
     align_grids,
     compute_boundary_distance,
     interpolate_indices,
-    make_edata,
+    make_nesting_info,
     map_child_boundaries_onto_parent_grid_indices,
     modify_child_mask,
     modify_child_topography,
@@ -450,7 +450,7 @@ class TestNesting:
             ),
         ],
     )
-    def test_make_edata_options(
+    def test_make_nesting_info_options(
         self,
         big_grid,
         small_grid,
@@ -463,7 +463,7 @@ class TestNesting:
         child_grid = small_grid
         parent_grid = big_grid
 
-        ds_nesting = make_edata(
+        ds_nesting = make_nesting_info(
             parent_grid,
             child_grid,
             include_bgc=include_bgc,
@@ -567,7 +567,7 @@ class TestNesting:
                 "west": True,
             },
         )
-        ds_nesting = make_edata(parent_grid, child_grid)
+        ds_nesting = make_nesting_info(parent_grid, child_grid)
 
         assert isinstance(child_grid.ds, xr.Dataset)
         assert isinstance(ds_nesting, xr.Dataset)
@@ -608,7 +608,7 @@ class TestNesting:
         for file_str in ["test_nesting", "test_nesting.nc"]:
             # Create a temporary filepath using the tmp_path fixture
             for filepath in [tmp_path / file_str, str(tmp_path / file_str)]:
-                make_edata(big_grid, child_grid_with_bgc, filepath)
+                make_nesting_info(big_grid, child_grid_with_bgc, filepath)
                 # saved_filenames = child_grid_with_bgc.save_nesting(filepath)
                 # Check if the .nc file was created
                 filepath = Path(filepath).with_suffix(".nc")


### PR DESCRIPTION
This PR renames all instances of `make_edata` to `make_nesting_info` since that is more intuitive to the user and edata is not explained anywhere in ROMS-Tools. 

- [ ] Tests still pass
- [ ] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
