### PR TITLE
Fix streaming bug

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -31,6 +31,8 @@
 * Integrate narrow-channel closing directly into `Grid.update_mask()` (internal `_close_narrow_channels`), iterating north–south and east–west up to 10 passes
 * short and long wave radiation time is shifted 1/2 a timestep sooner and have a dim of `rad_time` ([#586](https://github.com/CWorthy-ocean/roms-tools/pull/586))
 * The coarse UNIFIED BGC dataset used for testing was updated to have depths of 0 and 5 m available ([#589](https://github.com/CWorthy-ocean/roms-tools/pull/589))
+* When using the default of streaming from Copernicus for GLORYS output, the domain is now subset by the bounds of the domain to save read time. ([#604](https://github.com/CWorthy-ocean/roms-tools/pull/604))
+
 
 ### Documentation
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -31,8 +31,6 @@
 * Integrate narrow-channel closing directly into `Grid.update_mask()` (internal `_close_narrow_channels`), iterating north–south and east–west up to 10 passes
 * short and long wave radiation time is shifted 1/2 a timestep sooner and have a dim of `rad_time` ([#586](https://github.com/CWorthy-ocean/roms-tools/pull/586))
 * The coarse UNIFIED BGC dataset used for testing was updated to have depths of 0 and 5 m available ([#589](https://github.com/CWorthy-ocean/roms-tools/pull/589))
-* When using the default of streaming from Copernicus for GLORYS output, the domain is now subset by the bounds of the domain to save read time. ([#604](https://github.com/CWorthy-ocean/roms-tools/pull/604))
-
 * 2 checks added for a point source when plotting `CDRForcing.plot_distribution()`. Low hsc is treated as a point source ([#600](https://github.com/CWorthy-ocean/roms-tools/pull/600))
 
 ### Documentation

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -47,6 +47,7 @@
 
 * Corrected enclosed-basin filling in mask generation by iterating connected-component labels `1..nreg` in `_fill_enclosed_basins`, preventing spurious interior lakes; updated the enclosed-region test to expect a single connected wet region. ([#577](https://github.com/CWorthy-ocean/roms-tools/pull/577))
 * Fix timer logging messages during mask generation so durations render correctly when closing narrow channels and filling enclosed basins
+* Fix for hanging when using the default of streaming from Copernicus for GLORYS output. ([#604](https://github.com/CWorthy-ocean/roms-tools/pull/604))
 
 ## v3.5.0
 

--- a/roms_tools/datasets/lat_lon_datasets.py
+++ b/roms_tools/datasets/lat_lon_datasets.py
@@ -1088,6 +1088,13 @@ class GLORYSDefaultDataset(GLORYSDataset):
     def _load_from_copernicus(self) -> xr.Dataset:
         """Load a GLORYS dataset supporting streaming.
 
+        This reads in using zarr on the Copernicus Marine Data Store.
+        The impact of chunk_size_limit=-1 is to let the toolkit determine optimal chunking
+        based on the dataset and request parameters, which can help improve performance
+        when working with large datasets. So, this is dask-backed but does not use the
+        parameter _DEFAULT_LAT_LON_LATERAL_CHUNK for chunking, which does not work well
+        for streaming.
+
         Returns
         -------
         xr.Dataset
@@ -1112,15 +1119,22 @@ class GLORYSDefaultDataset(GLORYSDataset):
         #    },
         # )
 
+        bounds = self.initial_slice_bounds or {}
+        lat = bounds.get("latitude", (None, None))
+        lon = bounds.get("longitude", (None, None))
         ds = copernicusmarine.open_dataset(
             self.dataset_name,
             start_datetime=self.start_time,
             end_datetime=self.end_time
             if self.end_time is not None
             else self.start_time,
+            minimum_latitude=lat[0],
+            maximum_latitude=lat[1],
+            minimum_longitude=lon[0],
+            maximum_longitude=lon[1],
             service="arco-geo-series",
             coordinates_selection_method="outside",
-            chunk_size_limit=-1,
+            chunk_size_limit=-1,  # auto-chunks internally
         )
 
         return ds

--- a/roms_tools/datasets/lat_lon_datasets.py
+++ b/roms_tools/datasets/lat_lon_datasets.py
@@ -1119,19 +1119,12 @@ class GLORYSDefaultDataset(GLORYSDataset):
         #    },
         # )
 
-        bounds = self.initial_slice_bounds or {}
-        lat = bounds.get("latitude", (None, None))
-        lon = bounds.get("longitude", (None, None))
         ds = copernicusmarine.open_dataset(
             self.dataset_name,
             start_datetime=self.start_time,
             end_datetime=self.end_time
             if self.end_time is not None
             else self.start_time,
-            minimum_latitude=lat[0],
-            maximum_latitude=lat[1],
-            minimum_longitude=lon[0],
-            maximum_longitude=lon[1],
             service="arco-geo-series",
             coordinates_selection_method="outside",
             chunk_size_limit=-1,  # auto-chunks internally

--- a/roms_tools/datasets/lat_lon_datasets.py
+++ b/roms_tools/datasets/lat_lon_datasets.py
@@ -1115,19 +1115,13 @@ class GLORYSDefaultDataset(GLORYSDataset):
         ds = copernicusmarine.open_dataset(
             self.dataset_name,
             start_datetime=self.start_time,
-            end_datetime=self.end_time,
+            end_datetime=self.end_time
+            if self.end_time is not None
+            else self.start_time,
             service="arco-geo-series",
             coordinates_selection_method="outside",
             chunk_size_limit=-1,
         )
-        chunks = (
-            self.chunks
-            if self.chunks is not None
-            else get_dask_chunks(
-                self.dim_names, lateral_chunk=_DEFAULT_LAT_LON_LATERAL_CHUNK
-            )
-        )
-        ds = ds.chunk(chunks)
 
         return ds
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`

**Summary**

1. The chunking in `_load_from_copernicus()` in `lat_lon_datasets.py` was causing the Copernicus streaming to hang. I commented this out to avoid the issue since even a tiny grid hung meaning that any reasonably-sized grid would for sure hang too. The docs already steer users away from using streaming so I am not sure it is worth a lot of testing here to see if large domains with streaming from Copernicus would hit an issue specifically because of commenting out chunks with streaming vs. streaming with a large domain.
    1. An alternative solution would be to have the default be to download from Copernicus and then use that.
2. After that fix, the wrong day is grabbed for ini_time for `InitialConditions`  so I input `ini_time` to `end_time` for `_load_from_copernicuse()` if `end_time` is None which fixes it.

Addresses https://cworthy.atlassian.net/browse/CSD-872