### PR TITLE
River PR changes

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 * `from_file` is now a private function to `Grid`. Files are now loaded as `Grid(filename='grid.nc')` ([#573](https://github.com/CWorthy-ocean/roms-tools/pull/573))
 * The `ChildGrid` has been removed. Both a child and parent grid are created using `Grid`, and the functions `align_grids` and `make_edata` are called to adjust bathymetry and do the mapping ([#573](https://github.com/CWorthy-ocean/roms-tools/pull/573)).
+* Default river/CDR tracer concentrations are now read from `river_tracer_defaults.nc` and differ from the previous hardcoded values (e.g. DIC, NO3, ALK, temperature) ([#615](https://github.com/CWorthy-ocean/roms-tools/pull/615))
 
 ### New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ fallback_version = "9999"
 exclude = ["docs", "tests", "tests.*", "docs.*"]
 
 [tool.setuptools.package-data]
-roms_tools = ["py.typed", "datasets/data/*.nc"]
+roms_tools = ["py.typed"]
 
 [tool.ruff]
 fix = true

--- a/roms_tools/datasets/river_datasets.py
+++ b/roms_tools/datasets/river_datasets.py
@@ -43,6 +43,16 @@ class RiverBGCDataset(Protocol):
         """How interior temporal gaps in dynamic concentrations are filled."""
         ...
 
+    @property
+    def fill_value(self) -> float | None:
+        """Sentinel marking missing concentrations, or ``None`` if not used.
+
+        ``RiverForcing`` masks this value out of dynamic concentrations before
+        merging in fill defaults, so any dataset that uses a sentinel must
+        surface it here.
+        """
+        ...
+
     def forcing_concentrations(
         self,
         river_volume: xr.DataArray,
@@ -205,6 +215,10 @@ class RiverTracerDefaultsDataset(RiverBGCDataset):
     @property
     def temporal_interpolation(self) -> RiverBGCTemporalInterpolation:
         return "none"
+
+    @property
+    def fill_value(self) -> float | None:
+        return None
 
     def forcing_concentrations(
         self,
@@ -916,6 +930,13 @@ class Rivr2oRiverBGCDataset(RiverBGCDataset):
         in_range = (ds[time_dim].dt.year >= start_year) & (
             ds[time_dim].dt.year <= end_year
         )
+        if not bool(in_range.any()):
+            available = sorted({int(y) for y in ds[time_dim].dt.year.values})
+            raise ValueError(
+                f"No RIVR2O files cover the requested years {start_year}-{end_year}. "
+                f"Loaded files span years {available}. Provide RIVR2O files that "
+                "overlap the simulation window."
+            )
         return ds.sel({time_dim: ds[time_dim].where(in_range, drop=True)})
 
     def _adjust_lon_to_grid(self, lon: np.ndarray, *, straddle: bool) -> np.ndarray:

--- a/roms_tools/datasets/river_datasets.py
+++ b/roms_tools/datasets/river_datasets.py
@@ -116,7 +116,7 @@ def fill_river_bgc_concentrations(
 
 
 @dataclass(kw_only=True)
-class RiverTracerDefaultsDataset:
+class RiverTracerDefaultsDataset(RiverBGCDataset):
     """Default MARBL river tracer concentrations.
 
     Used as the ``"CONSTANTS"`` ``bgc_source`` and as the default ``fill`` source
@@ -713,7 +713,7 @@ _DOP_FROM_POC = 1 / 276
 
 
 @dataclass(kw_only=True)
-class Rivr2oRiverBGCDataset:
+class Rivr2oRiverBGCDataset(RiverBGCDataset):
     """River BGC export data from the RIVR2O river inputs product.
 
     The product is distributed as one NetCDF file per year. Each file contains

--- a/roms_tools/setup/river_forcing.py
+++ b/roms_tools/setup/river_forcing.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -15,6 +15,7 @@ from roms_tools.constants import MAX_DISTINCT_COLORS
 from roms_tools.datasets.river_datasets import (
     DaiRiverDataset,
     RiverBGCDataset,
+    RiverDataset,
     RiverTracerDefaultsDataset,
     Rivr2oRiverBGCDataset,
     fill_river_bgc_concentrations,
@@ -190,7 +191,7 @@ class RiverForcing:
     ds: xr.Dataset = field(init=False, repr=False)
     """An xarray Dataset containing post-processed variables ready for input into
     ROMS."""
-    climatology: xr.Dataset = field(init=False, repr=False)
+    climatology: bool = field(init=False, repr=False)
     """Indicates whether the final river forcing is climatological."""
     _bgc_dataset: RiverBGCDataset | None = field(
         default=None, init=False, repr=False, compare=False
@@ -340,21 +341,22 @@ class RiverForcing:
                         )
                     seen_tuples.add(idx_pair)
 
-    def _get_data(self):
-        data_dict = {
-            "start_time": self.start_time,
-            "end_time": self.end_time,
-            "climatology": self.source["climatology"],
-        }
-
-        if self.source["name"] == "DAI":
-            if "path" in self.source.keys():
-                data_dict["filename"] = self.source["path"]
-            data = DaiRiverDataset(**data_dict)
-        else:
+    def _get_data(self) -> RiverDataset:
+        source = self.source
+        if source is None:
+            raise RuntimeError("source must be set.")
+        if source["name"] != "DAI":
             raise ValueError('Only "DAI" is a valid option for source["name"].')
 
-        return data
+        data_dict: dict[str, Any] = {
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "climatology": source["climatology"],
+        }
+        if "path" in source:
+            data_dict["filename"] = source["path"]
+
+        return DaiRiverDataset(**data_dict)
 
     def _get_bgc_dataset(self) -> RiverBGCDataset:
         """Instantiate the BGC dataset for the configured ``bgc_source``."""
@@ -467,7 +469,7 @@ class RiverForcing:
             self._set_river_tracer_values(ds, tracer_name, values)
         return ds
 
-    def _move_rivers_to_closest_coast(self, target_coords, data):
+    def _move_rivers_to_closest_coast(self, target_coords, data: RiverDataset):
         """Move river mouths to the closest coastal grid cell.
 
         This method computes the closest coastal grid point to each river mouth
@@ -481,8 +483,8 @@ class RiverForcing:
             - "lat" (xarray.DataArray): Latitude coordinates of the target grid points.
             - "straddle" (bool): A flag indicating whether the river mouth crosses the International Date Line.
 
-        data : object
-            An object that contains the dataset and related variables. It must have the following attributes:
+        data : RiverDataset
+            A river dataset providing the following attributes:
             - `ds`: The dataset containing river information.
             - `var_names`: A dictionary of variable names in the dataset (e.g., longitude, latitude, station names).
             - `dim_names`: A dictionary containing dimension names for the dataset (e.g., "station", "eta_rho", "xi_rho").
@@ -525,7 +527,7 @@ class RiverForcing:
 
         return river_indices
 
-    def _create_river_forcing(self, data):
+    def _create_river_forcing(self, data: RiverDataset):
         """Create river forcing data for volume flux and tracers (temperature, salinity,
         BGC tracers).
 
@@ -538,8 +540,8 @@ class RiverForcing:
 
         Parameters
         ----------
-        data : object
-            An object containing the necessary dataset and variables for river forcing creation. The object must have the following attributes:
+        data : RiverDataset
+            A river dataset providing the necessary data and variables for river forcing creation, with the following attributes:
             - `ds`: The dataset containing the river flux, ratio, and other related variables.
             - `var_names`: A dictionary mapping variable names (e.g., `"flux"`, `"ratio"`, `"name"`) to the corresponding variable names in the dataset.
             - `dim_names`: A dictionary mapping dimension names (e.g., `"time"`, `"station"`) to the corresponding dimension names in the dataset.
@@ -551,7 +553,10 @@ class RiverForcing:
             - `river_volume`: A `DataArray` representing the river volume flux (m³/s).
             - `river_tracer`: A `DataArray` representing tracer data for temperature, salinity and BGC tracers (if specified) for each river over time.
         """
-        if self.source["climatology"]:
+        source = self.source
+        if source is None:
+            raise RuntimeError("source must be set.")
+        if source["climatology"]:
             self.climatology = True
         else:
             if self.convert_to_climatology in ["never", "if_any_missing"]:

--- a/roms_tools/setup/river_forcing.py
+++ b/roms_tools/setup/river_forcing.py
@@ -1,4 +1,5 @@
 import logging
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -60,21 +61,50 @@ class FillSource(BaseModel):
     name: Literal["CONSTANTS"] = "CONSTANTS"
 
 
-class ConstantsBgcSource(BaseModel):
+class BgcSourceModel(BaseModel, ABC):
+    """Base for validated BGC source configurations.
+
+    Each subclass is one valid BGC source: it declares its discriminator
+    ``name`` and knows how to build its dataset via ``build_dataset``. Adding a
+    source means adding a subclass and listing it in ``BgcSource`` — no changes
+    to ``RiverForcing`` dispatch logic.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    fill: FillSource = Field(default_factory=FillSource)
+
+    @abstractmethod
+    def build_dataset(
+        self, *, start_time: datetime, end_time: datetime
+    ) -> RiverBGCDataset:
+        """Instantiate the BGC dataset this source describes."""
+        ...
+
+
+class ConstantsBgcSource(BgcSourceModel):
     """Constant default MARBL river tracer concentrations."""
 
-    model_config = ConfigDict(extra="forbid")
     name: Literal["CONSTANTS"] = "CONSTANTS"
-    fill: FillSource = Field(default_factory=FillSource)
+
+    def build_dataset(
+        self, *, start_time: datetime, end_time: datetime
+    ) -> RiverBGCDataset:
+        return RiverTracerDefaultsDataset()
 
 
-class Rivr2oBgcSource(BaseModel):
+class Rivr2oBgcSource(BgcSourceModel):
     """River BGC export from the RIVR2O product (one NetCDF file per year)."""
 
-    model_config = ConfigDict(extra="forbid")
     name: Literal["RIVR2O"] = "RIVR2O"
     path: str | Path | list[str | Path]
-    fill: FillSource = Field(default_factory=FillSource)
+
+    def build_dataset(
+        self, *, start_time: datetime, end_time: datetime
+    ) -> RiverBGCDataset:
+        return Rivr2oRiverBGCDataset(
+            filename=self.path, start_time=start_time, end_time=end_time
+        )
 
 
 # Discriminated on ``name``: these variant classes are the registry of valid
@@ -377,29 +407,24 @@ class RiverForcing:
     def _get_bgc_dataset(self) -> RiverBGCDataset:
         """Instantiate the BGC dataset for the configured ``bgc_source``.
 
-        ``bgc_source`` is a validated ``BgcSource`` model (see ``_input_checks``),
-        so this just dispatches on the variant type.
+        ``bgc_source`` is a validated ``BgcSourceModel`` (see ``_input_checks``),
+        which knows how to build its own dataset.
         """
         if self._bgc_dataset is not None:
             return self._bgc_dataset
 
-        match self.bgc_source:
-            case ConstantsBgcSource():
-                self._bgc_dataset = RiverTracerDefaultsDataset()
-            case Rivr2oBgcSource(path=path):
-                self._bgc_dataset = Rivr2oRiverBGCDataset(
-                    filename=path,
-                    start_time=self.start_time,
-                    end_time=self.end_time,
-                )
-            case _:
-                raise RuntimeError("bgc_source must be a validated BgcSource model.")
+        bgc_source = self.bgc_source
+        if not isinstance(bgc_source, BgcSourceModel):
+            raise RuntimeError("bgc_source must be a validated BgcSource model.")
+        self._bgc_dataset = bgc_source.build_dataset(
+            start_time=self.start_time, end_time=self.end_time
+        )
         return self._bgc_dataset
 
     def _get_fill_defaults(self) -> dict[str, float]:
         """Load scalar fill concentrations for missing or non-finite BGC tracers."""
         bgc_source = self.bgc_source
-        if not isinstance(bgc_source, ConstantsBgcSource | Rivr2oBgcSource):
+        if not isinstance(bgc_source, BgcSourceModel):
             raise RuntimeError("bgc_source must be a validated BgcSource model.")
         return _FILL_DATASET_MAP[bgc_source.fill.name]().defaults
 
@@ -431,7 +456,7 @@ class RiverForcing:
     def _apply_bgc_tracers(self, ds: xr.Dataset) -> xr.Dataset:
         """Apply BGC tracer concentrations from the primary source, with fill."""
         bgc_source = self.bgc_source
-        if not isinstance(bgc_source, ConstantsBgcSource | Rivr2oBgcSource):
+        if not isinstance(bgc_source, BgcSourceModel):
             raise RuntimeError("bgc_source must be a validated BgcSource model.")
         bgc_data = self._get_bgc_dataset()
         if isinstance(bgc_data, RiverTracerDefaultsDataset) and (

--- a/roms_tools/setup/river_forcing.py
+++ b/roms_tools/setup/river_forcing.py
@@ -50,6 +50,7 @@ from roms_tools.utils import save_datasets
 INCLUDE_ALL_RIVER_NAMES = "all"
 MAX_RIVERS_TO_PLOT = 20  # must be <= MAX_DISTINCT_COLORS
 DISCHARGE_CLIMATOLOGY_ATTR = "discharge_climatology"
+VALID_CONVERT_TO_CLIMATOLOGY = ("never", "if_any_missing", "always")
 
 TRiverIndex: TypeAlias = dict[tuple[int, int], list[str]]
 
@@ -285,6 +286,11 @@ class RiverForcing:
         self.ds = ds
 
     def _input_checks(self):
+        if self.convert_to_climatology not in VALID_CONVERT_TO_CLIMATOLOGY:
+            raise ValueError(
+                f'Invalid convert_to_climatology "{self.convert_to_climatology}". '
+                f"Valid options: {', '.join(VALID_CONVERT_TO_CLIMATOLOGY)}."
+            )
         self.source = self._normalized_source()
         self.bgc_source = self._normalized_bgc_source()
         self._validate_indices()
@@ -478,7 +484,7 @@ class RiverForcing:
         )
         dynamic = _mask_invalid_dynamic_bgc_concentrations(
             dynamic,
-            fill_value=getattr(bgc_data, "fill_value", None),
+            fill_value=bgc_data.fill_value,
         )
         if bgc_data.temporal_interpolation == "calendar_year":
             dynamic = interpolate_dynamic_bgc_by_calendar_year(dynamic, ds["abs_time"])

--- a/roms_tools/setup/river_forcing.py
+++ b/roms_tools/setup/river_forcing.py
@@ -1,14 +1,14 @@
 import logging
 from collections import defaultdict
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias
 
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from roms_tools import Grid
 from roms_tools.constants import MAX_DISTINCT_COLORS
@@ -52,29 +52,44 @@ DISCHARGE_CLIMATOLOGY_ATTR = "discharge_climatology"
 
 TRiverIndex: TypeAlias = dict[tuple[int, int], list[str]]
 
-RiverBGCSource: TypeAlias = dict[
-    str, str | Path | Sequence[str | Path] | bool | dict[str, str]
-]
 
-_BGC_DATASET_MAP: dict[str, type[RiverBGCDataset]] = {
-    "CONSTANTS": RiverTracerDefaultsDataset,
-    "RIVR2O": Rivr2oRiverBGCDataset,
-}
+class FillSource(BaseModel):
+    """Secondary BGC source supplying tracers missing from the primary result."""
+
+    model_config = ConfigDict(extra="forbid")
+    name: Literal["CONSTANTS"] = "CONSTANTS"
+
+
+class ConstantsBgcSource(BaseModel):
+    """Constant default MARBL river tracer concentrations."""
+
+    model_config = ConfigDict(extra="forbid")
+    name: Literal["CONSTANTS"] = "CONSTANTS"
+    fill: FillSource = Field(default_factory=FillSource)
+
+
+class Rivr2oBgcSource(BaseModel):
+    """River BGC export from the RIVR2O product (one NetCDF file per year)."""
+
+    model_config = ConfigDict(extra="forbid")
+    name: Literal["RIVR2O"] = "RIVR2O"
+    path: str | Path | list[str | Path]
+    fill: FillSource = Field(default_factory=FillSource)
+
+
+# Discriminated on ``name``: these variant classes are the registry of valid
+# BGC sources. Users pass a plain dict; the adapter validates and coerces it,
+# rejecting unknown names, missing RIVR2O paths, and unexpected keys.
+BgcSource: TypeAlias = Annotated[
+    ConstantsBgcSource | Rivr2oBgcSource, Field(discriminator="name")
+]
+_BGC_SOURCE_ADAPTER: TypeAdapter[ConstantsBgcSource | Rivr2oBgcSource] = TypeAdapter(
+    BgcSource
+)
 
 _FILL_DATASET_MAP: dict[str, type[RiverTracerDefaultsDataset]] = {
     "CONSTANTS": RiverTracerDefaultsDataset,
 }
-
-
-def _get_bgc_fill_source(bgc_source: RiverBGCSource) -> dict[str, str]:
-    r"""Return normalized ``bgc_source["fill"]`` with a string ``name`` key."""
-    raw_fill = bgc_source.get("fill", {"name": "CONSTANTS"})
-    if not isinstance(raw_fill, dict):
-        raise ValueError('bgc_source["fill"] must be a dictionary.')
-    fill_name = raw_fill.get("name")
-    if not isinstance(fill_name, str):
-        raise ValueError('bgc_source["fill"] must include a "name".')
-    return {"name": fill_name}
 
 
 def _mask_invalid_dynamic_bgc_concentrations(
@@ -177,8 +192,12 @@ class RiverForcing:
     """Determines when to compute climatology for river forcing."""
     include_bgc: bool = False
     """Whether to include BGC tracers."""
-    bgc_source: RiverBGCSource | None = None
-    """Primary and fill BGC dataset configuration."""
+    bgc_source: dict | BgcSource | None = None
+    """Primary and fill BGC dataset configuration.
+
+    Accepts a plain dict on input; normalized to a validated ``BgcSource`` model
+    (or ``None`` when ``include_bgc`` is False) during initialization.
+    """
     model_reference_date: datetime = datetime(2000, 1, 1)
     """Reference date for the ROMS simulation."""
 
@@ -254,44 +273,28 @@ class RiverForcing:
         # Set 'climatology' to False if not provided in 'source'
         return {**source, "climatology": source.get("climatology", False)}
 
-    def _normalized_bgc_source(self) -> RiverBGCSource | None:
-        """Apply defaults to ``bgc_source`` and validate it when BGC is enabled."""
+    def _normalized_bgc_source(self) -> BgcSource | None:
+        """Validate ``bgc_source`` into a typed model when BGC is enabled.
+
+        Returns ``None`` when BGC is disabled. Otherwise the input dict is
+        validated into the discriminated ``BgcSource`` union, which applies the
+        ``CONSTANTS`` default and rejects unknown names, missing RIVR2O paths,
+        and unexpected keys.
+        """
         if not self.include_bgc:
             if self.bgc_source is not None:
                 logging.warning(
                     "`bgc_source` is ignored because `include_bgc` is False."
                 )
-            return self.bgc_source
+            return None
 
-        bgc_source: RiverBGCSource = (
+        raw: Any = (
             self.bgc_source if self.bgc_source is not None else {"name": "CONSTANTS"}
         )
-
-        if "name" not in bgc_source:
-            raise ValueError("`bgc_source` must include a 'name'.")
-        if bgc_source["name"] not in _BGC_DATASET_MAP:
-            valid = ", ".join(_BGC_DATASET_MAP)
-            raise ValueError(
-                f'Invalid bgc_source["name"] "{bgc_source["name"]}". '
-                f"Valid options: {valid}."
-            )
-        if bgc_source["name"] == "RIVR2O" and "path" not in bgc_source:
-            raise ValueError(
-                '`bgc_source` must include a "path" when name is "RIVR2O".'
-            )
-
-        fill_source = _get_bgc_fill_source(bgc_source)
-        if fill_source["name"] not in _FILL_DATASET_MAP:
-            valid = ", ".join(_FILL_DATASET_MAP)
-            raise ValueError(
-                f'Invalid bgc_source["fill"]["name"] "{fill_source["name"]}". '
-                f"Valid options: {valid}."
-            )
-
-        bgc_source = {**bgc_source, "fill": fill_source}
-        if "path" in bgc_source:
-            bgc_source = {**bgc_source, "path": serialize_paths(bgc_source["path"])}
-        return bgc_source
+        if isinstance(raw, dict) and "path" in raw:
+            # Normalize Path -> str so the stored config round-trips through YAML.
+            raw = {**raw, "path": serialize_paths(raw["path"])}
+        return _BGC_SOURCE_ADAPTER.validate_python(raw)
 
     def _validate_indices(self) -> None:
         """Validate the format of a provided ``indices`` mapping, if any."""
@@ -374,45 +377,31 @@ class RiverForcing:
     def _get_bgc_dataset(self) -> RiverBGCDataset:
         """Instantiate the BGC dataset for the configured ``bgc_source``.
 
-        ``bgc_source`` is normalized and validated in ``_input_checks`` (``name``
-        is a key of ``_BGC_DATASET_MAP``, and ``"RIVR2O"`` carries a ``"path"``),
-        so this dispatches on the name and only narrows the path value's type.
+        ``bgc_source`` is a validated ``BgcSource`` model (see ``_input_checks``),
+        so this just dispatches on the variant type.
         """
         if self._bgc_dataset is not None:
             return self._bgc_dataset
 
-        bgc_source = self.bgc_source
-        if bgc_source is None:
-            raise RuntimeError("bgc_source must be set.")
-
-        if bgc_source["name"] == "CONSTANTS":
-            self._bgc_dataset = RiverTracerDefaultsDataset()
-            return self._bgc_dataset
-
-        path = bgc_source["path"]
-        if not isinstance(path, str | Path | list):
-            raise ValueError('bgc_source must include a "path" when name is "RIVR2O".')
-        self._bgc_dataset = Rivr2oRiverBGCDataset(
-            filename=path,
-            start_time=self.start_time,
-            end_time=self.end_time,
-        )
+        match self.bgc_source:
+            case ConstantsBgcSource():
+                self._bgc_dataset = RiverTracerDefaultsDataset()
+            case Rivr2oBgcSource(path=path):
+                self._bgc_dataset = Rivr2oRiverBGCDataset(
+                    filename=path,
+                    start_time=self.start_time,
+                    end_time=self.end_time,
+                )
+            case _:
+                raise RuntimeError("bgc_source must be a validated BgcSource model.")
         return self._bgc_dataset
 
     def _get_fill_defaults(self) -> dict[str, float]:
         """Load scalar fill concentrations for missing or non-finite BGC tracers."""
         bgc_source = self.bgc_source
-        if bgc_source is None:
-            raise RuntimeError("bgc_source must be set.")
-        fill_source = _get_bgc_fill_source(bgc_source)
-        fill_name = fill_source["name"]
-        if fill_name not in _FILL_DATASET_MAP:
-            valid = ", ".join(_FILL_DATASET_MAP)
-            raise ValueError(
-                f'Invalid bgc_source["fill"]["name"] "{fill_name}". '
-                f"Valid options: {valid}."
-            )
-        return _FILL_DATASET_MAP[fill_name]().defaults
+        if not isinstance(bgc_source, ConstantsBgcSource | Rivr2oBgcSource):
+            raise RuntimeError("bgc_source must be a validated BgcSource model.")
+        return _FILL_DATASET_MAP[bgc_source.fill.name]().defaults
 
     def _get_river_sample_coords(
         self, river_names: list[str]
@@ -441,12 +430,12 @@ class RiverForcing:
 
     def _apply_bgc_tracers(self, ds: xr.Dataset) -> xr.Dataset:
         """Apply BGC tracer concentrations from the primary source, with fill."""
-        if self.bgc_source is None:
-            raise RuntimeError("bgc_source must be set.")
+        bgc_source = self.bgc_source
+        if not isinstance(bgc_source, ConstantsBgcSource | Rivr2oBgcSource):
+            raise RuntimeError("bgc_source must be a validated BgcSource model.")
         bgc_data = self._get_bgc_dataset()
-        fill_source = _get_bgc_fill_source(self.bgc_source)
         if isinstance(bgc_data, RiverTracerDefaultsDataset) and (
-            fill_source["name"] == "CONSTANTS"
+            bgc_source.fill.name == "CONSTANTS"
         ):
             fill_defaults = bgc_data.defaults
         else:

--- a/roms_tools/setup/river_forcing.py
+++ b/roms_tools/setup/river_forcing.py
@@ -236,110 +236,123 @@ class RiverForcing:
         self.ds = ds
 
     def _input_checks(self):
-        if self.source is None:
-            self.source = {"name": "DAI"}
+        self.source = self._normalized_source()
+        self.bgc_source = self._normalized_bgc_source()
+        self._validate_indices()
 
-        if "name" not in self.source:
+    def _normalized_source(self) -> RawDataSource:
+        """Apply defaults to ``source`` and validate its required keys."""
+        source: RawDataSource = (
+            self.source if self.source is not None else {"name": "DAI"}
+        )
+
+        if "name" not in source:
             raise ValueError("`source` must include a 'name'.")
-        if "path" not in self.source:
-            if self.source["name"] != "DAI":
-                raise ValueError("`source` must include a 'path'.")
+        if "path" not in source and source["name"] != "DAI":
+            raise ValueError("`source` must include a 'path'.")
 
         # Set 'climatology' to False if not provided in 'source'
-        self.source = {
-            **self.source,
-            "climatology": self.source.get("climatology", False),
-        }
+        return {**source, "climatology": source.get("climatology", False)}
 
-        if self.include_bgc:
-            if self.bgc_source is None:
-                self.bgc_source = {"name": "CONSTANTS"}
-            elif "name" not in self.bgc_source:
-                raise ValueError("`bgc_source` must include a 'name'.")
-            elif self.bgc_source["name"] not in ("CONSTANTS", "RIVR2O"):
-                raise ValueError(
-                    'Only "CONSTANTS" and "RIVR2O" are valid options for '
-                    'bgc_source["name"].'
+    def _normalized_bgc_source(self) -> RiverBGCSource | None:
+        """Apply defaults to ``bgc_source`` and validate it when BGC is enabled."""
+        if not self.include_bgc:
+            if self.bgc_source is not None:
+                logging.warning(
+                    "`bgc_source` is ignored because `include_bgc` is False."
                 )
-            elif self.bgc_source["name"] == "RIVR2O" and "path" not in self.bgc_source:
+            return self.bgc_source
+
+        bgc_source: RiverBGCSource = (
+            self.bgc_source if self.bgc_source is not None else {"name": "CONSTANTS"}
+        )
+
+        if "name" not in bgc_source:
+            raise ValueError("`bgc_source` must include a 'name'.")
+        if bgc_source["name"] not in _BGC_DATASET_MAP:
+            valid = ", ".join(_BGC_DATASET_MAP)
+            raise ValueError(
+                f'Invalid bgc_source["name"] "{bgc_source["name"]}". '
+                f"Valid options: {valid}."
+            )
+        if bgc_source["name"] == "RIVR2O" and "path" not in bgc_source:
+            raise ValueError(
+                '`bgc_source` must include a "path" when name is "RIVR2O".'
+            )
+
+        fill_source = _get_bgc_fill_source(bgc_source)
+        if fill_source["name"] not in _FILL_DATASET_MAP:
+            valid = ", ".join(_FILL_DATASET_MAP)
+            raise ValueError(
+                f'Invalid bgc_source["fill"]["name"] "{fill_source["name"]}". '
+                f"Valid options: {valid}."
+            )
+
+        bgc_source = {**bgc_source, "fill": fill_source}
+        if "path" in bgc_source:
+            bgc_source = {**bgc_source, "path": serialize_paths(bgc_source["path"])}
+        return bgc_source
+
+    def _validate_indices(self) -> None:
+        """Validate the format of a provided ``indices`` mapping, if any."""
+        if self.indices is None:
+            return
+        if not isinstance(self.indices, dict):
+            raise ValueError("`indices` must be a dictionary.")
+
+        # Ensure the dictionary contains at least one river
+        if len(self.indices) == 0:
+            raise ValueError(
+                "The provided 'indices' dictionary must contain at least one river."
+            )
+
+        for river_name, river_data in self.indices.items():
+            self._validate_river_index_entry(river_name, river_data)
+
+    def _validate_river_index_entry(self, river_name, river_data) -> None:
+        """Validate one ``indices`` entry: a river name and its list of locations."""
+        if not isinstance(river_name, str):
+            raise ValueError(f"River name `{river_name}` must be a string.")
+
+        if not isinstance(river_data, list):
+            raise ValueError(f"Data for river `{river_name}` must be a list of tuples.")
+
+        seen_tuples = set()
+        # Ensure each element in the list is a tuple of length 2
+        for idx_pair in river_data:
+            if not isinstance(idx_pair, tuple) or len(idx_pair) != 2:
                 raise ValueError(
-                    '`bgc_source` must include a "path" when name is "RIVR2O".'
+                    f"Each item for river `{river_name}` must be a tuple of length 2 representing (eta_rho, xi_rho)."
                 )
-            fill_source = _get_bgc_fill_source(self.bgc_source)
-            if fill_source["name"] not in _FILL_DATASET_MAP:
-                valid = ", ".join(_FILL_DATASET_MAP)
+
+            eta_rho, xi_rho = idx_pair
+
+            # Ensure both eta_rho and xi_rho are integers
+            if not isinstance(eta_rho, int):
                 raise ValueError(
-                    f'Invalid bgc_source["fill"]["name"] "{fill_source["name"]}". '
-                    f"Valid options: {valid}."
+                    f"First element of tuple for river `{river_name}` must be an integer (eta_rho), but got {type(eta_rho)}."
                 )
-            self.bgc_source = {
-                **self.bgc_source,
-                "fill": fill_source,
-            }
-            if "path" in self.bgc_source:
-                self.bgc_source = {
-                    **self.bgc_source,
-                    "path": serialize_paths(self.bgc_source["path"]),
-                }
-        elif self.bgc_source is not None:
-            logging.warning("`bgc_source` is ignored because `include_bgc` is False.")
-
-        # Check if 'indices' is provided and has the correct format
-        if self.indices is not None:
-            if not isinstance(self.indices, dict):
-                raise ValueError("`indices` must be a dictionary.")
-
-            # Ensure the dictionary contains at least one river
-            if len(self.indices) == 0:
+            if not isinstance(xi_rho, int):
                 raise ValueError(
-                    "The provided 'indices' dictionary must contain at least one river."
+                    f"Second element of tuple for river `{river_name}` must be an integer (xi_rho), but got {type(xi_rho)}."
                 )
 
-            for river_name, river_data in self.indices.items():
-                if not isinstance(river_name, str):
-                    raise ValueError(f"River name `{river_name}` must be a string.")
+            # Check that eta_rho and xi_rho are within the valid range
+            if not (0 <= eta_rho < len(self.grid.ds.eta_rho)):
+                raise ValueError(
+                    f"Value of eta_rho for river `{river_name}` ({eta_rho}) is out of valid range [0, {len(self.grid.ds.eta_rho) - 1}]."
+                )
+            if not (0 <= xi_rho < len(self.grid.ds.xi_rho)):
+                raise ValueError(
+                    f"Value of xi_rho for river `{river_name}` ({xi_rho}) is out of valid range [0, {len(self.grid.ds.xi_rho) - 1}]."
+                )
 
-                if not isinstance(river_data, list):
-                    raise ValueError(
-                        f"Data for river `{river_name}` must be a list of tuples."
-                    )
-
-                seen_tuples = set()
-                # Ensure each element in the list is a tuple of length 2
-                for idx_pair in river_data:
-                    if not isinstance(idx_pair, tuple) or len(idx_pair) != 2:
-                        raise ValueError(
-                            f"Each item for river `{river_name}` must be a tuple of length 2 representing (eta_rho, xi_rho)."
-                        )
-
-                    eta_rho, xi_rho = idx_pair
-
-                    # Ensure both eta_rho and xi_rho are integers
-                    if not isinstance(eta_rho, int):
-                        raise ValueError(
-                            f"First element of tuple for river `{river_name}` must be an integer (eta_rho), but got {type(eta_rho)}."
-                        )
-                    if not isinstance(xi_rho, int):
-                        raise ValueError(
-                            f"Second element of tuple for river `{river_name}` must be an integer (xi_rho), but got {type(xi_rho)}."
-                        )
-
-                    # Check that eta_rho and xi_rho are within the valid range
-                    if not (0 <= eta_rho < len(self.grid.ds.eta_rho)):
-                        raise ValueError(
-                            f"Value of eta_rho for river `{river_name}` ({eta_rho}) is out of valid range [0, {len(self.grid.ds.eta_rho) - 1}]."
-                        )
-                    if not (0 <= xi_rho < len(self.grid.ds.xi_rho)):
-                        raise ValueError(
-                            f"Value of xi_rho for river `{river_name}` ({xi_rho}) is out of valid range [0, {len(self.grid.ds.xi_rho) - 1}]."
-                        )
-
-                    # Check for duplicate tuples for a single river
-                    if idx_pair in seen_tuples:
-                        raise ValueError(
-                            f"Duplicate location {idx_pair} found for river `{river_name}`."
-                        )
-                    seen_tuples.add(idx_pair)
+            # Check for duplicate tuples for a single river
+            if idx_pair in seen_tuples:
+                raise ValueError(
+                    f"Duplicate location {idx_pair} found for river `{river_name}`."
+                )
+            seen_tuples.add(idx_pair)
 
     def _get_data(self) -> RiverDataset:
         source = self.source
@@ -359,29 +372,25 @@ class RiverForcing:
         return DaiRiverDataset(**data_dict)
 
     def _get_bgc_dataset(self) -> RiverBGCDataset:
-        """Instantiate the BGC dataset for the configured ``bgc_source``."""
+        """Instantiate the BGC dataset for the configured ``bgc_source``.
+
+        ``bgc_source`` is normalized and validated in ``_input_checks`` (``name``
+        is a key of ``_BGC_DATASET_MAP``, and ``"RIVR2O"`` carries a ``"path"``),
+        so this dispatches on the name and only narrows the path value's type.
+        """
         if self._bgc_dataset is not None:
             return self._bgc_dataset
 
         bgc_source = self.bgc_source
         if bgc_source is None:
             raise RuntimeError("bgc_source must be set.")
-        source_name = str(bgc_source["name"])
-        if source_name not in _BGC_DATASET_MAP:
-            valid = ", ".join(_BGC_DATASET_MAP)
-            raise ValueError(
-                f'Invalid bgc_source["name"] "{source_name}". Valid options: {valid}.'
-            )
-        if source_name == "CONSTANTS":
+
+        if bgc_source["name"] == "CONSTANTS":
             self._bgc_dataset = RiverTracerDefaultsDataset()
             return self._bgc_dataset
-        path = bgc_source.get("path")
-        if (
-            path is None
-            or isinstance(path, bool)
-            or isinstance(path, dict)
-            or not isinstance(path, str | Path | list)
-        ):
+
+        path = bgc_source["path"]
+        if not isinstance(path, str | Path | list):
             raise ValueError('bgc_source must include a "path" when name is "RIVR2O".')
         self._bgc_dataset = Rivr2oRiverBGCDataset(
             filename=path,

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -169,7 +169,11 @@ def calendar_midmonth_dates(start_time: datetime, end_time: datetime) -> list[da
             month = 1
             year += 1
     if not dates:
-        raise ValueError("No mid-month dates fall between start_time and end_time.")
+        # Window is shorter than a month and skips every 15th; fall back to a
+        # single representative mid-month date clamped into the window so the
+        # correct climatology month is still selected.
+        candidate = datetime(start_time.year, start_time.month, 15)
+        dates.append(min(max(candidate, start_time), end_time))
     return dates
 
 

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -1513,7 +1513,9 @@ def deserialize_datetime(
     return value
 
 
-def serialize_source_dict(src: dict[str, Any] | None) -> dict[str, Any] | None:
+def serialize_source_dict(
+    src: dict[str, Any] | BaseModel | None,
+) -> dict[str, Any] | None:
     """Serialize a source or BGC source dictionary for YAML or JSON output.
 
     This function performs the following transformations:
@@ -1539,7 +1541,10 @@ def serialize_source_dict(src: dict[str, Any] | None) -> dict[str, Any] | None:
     if src is None:
         return None
 
-    src = deepcopy(src)
+    if isinstance(src, BaseModel):
+        src = src.model_dump(mode="python")
+    else:
+        src = deepcopy(src)
 
     # Serialize paths
     if "path" in src:

--- a/roms_tools/tests/test_datasets/test_river_datasets.py
+++ b/roms_tools/tests/test_datasets/test_river_datasets.py
@@ -164,6 +164,27 @@ class TestRivr2oRiverBGCDataset:
         assert dataset.ds.sizes["time"] == 1
         assert dataset.ds.time.dt.year.item() == 2000
 
+    def test_window_outside_loaded_files_raises_clear_error(self, tmp_path):
+        files, _, _ = self._make_files(tmp_path, years=(2000, 2001))
+
+        with pytest.raises(
+            ValueError, match="No RIVR2O files cover the requested years 2010-2011"
+        ):
+            Rivr2oRiverBGCDataset(
+                filename=files,
+                start_time=datetime(2010, 1, 1),
+                end_time=datetime(2011, 12, 31),
+            )
+
+    def test_fill_value_exposed_for_protocol(self, tmp_path):
+        files, _, _ = self._make_files(tmp_path)
+        dataset = Rivr2oRiverBGCDataset(
+            filename=files,
+            start_time=datetime(2000, 1, 1),
+            end_time=datetime(2001, 12, 31),
+        )
+        assert dataset.fill_value == RIVR2O_FILL_VALUE
+
     def test_sample_at_points(self, tmp_path):
         files, lat, lon = self._make_files(tmp_path)
 

--- a/roms_tools/tests/test_setup/test_river_forcing.py
+++ b/roms_tools/tests/test_setup/test_river_forcing.py
@@ -761,7 +761,7 @@ class TestRiverForcingBGCSource:
             include_bgc=True,
         )
 
-        assert river_forcing.bgc_source == {
+        assert river_forcing.bgc_source.model_dump() == {
             "name": "CONSTANTS",
             "fill": {"name": "CONSTANTS"},
         }
@@ -775,7 +775,7 @@ class TestRiverForcingBGCSource:
         np.testing.assert_allclose(float(alk.min()), defaults["ALK"], rtol=1e-6)
 
     def test_bgc_rivr2o_requires_path(self, iceland_test_grid, single_cell_indices):
-        with pytest.raises(ValueError, match='must include a "path"'):
+        with pytest.raises(ValueError, match="path"):
             RiverForcing(
                 grid=iceland_test_grid,
                 start_time=datetime(1998, 1, 1),
@@ -812,7 +812,7 @@ class TestRiverForcingBGCSource:
             include_bgc=True,
             bgc_source={"name": "RIVR2O", "path": str(path)},
         )
-        assert river_forcing.bgc_source["fill"] == {"name": "CONSTANTS"}
+        assert river_forcing.bgc_source.fill.name == "CONSTANTS"
 
     def test_rivr2o_climatology_discharge_repeats_bgc_varies_by_year(
         self, tmp_path, iceland_test_grid, single_cell_indices

--- a/roms_tools/tests/test_setup/test_river_forcing.py
+++ b/roms_tools/tests/test_setup/test_river_forcing.py
@@ -265,6 +265,15 @@ class TestRiverForcingGeneral:
                 source={"path": "river_data.nc"},
             )
 
+    def test_invalid_convert_to_climatology(self, iceland_test_grid):
+        with pytest.raises(ValueError, match="Invalid convert_to_climatology"):
+            RiverForcing(
+                grid=iceland_test_grid,
+                start_time=datetime(1998, 1, 1),
+                end_time=datetime(1998, 3, 1),
+                convert_to_climatology="sometimes",
+            )
+
     def test_river_forcing_plot(self, river_forcing_with_bgc):
         """Test plot methods with and without specifying river_names."""
         river_names = list(river_forcing_with_bgc.indices.keys())[0:2]

--- a/roms_tools/tests/test_setup/test_tracer_defaults.py
+++ b/roms_tools/tests/test_setup/test_tracer_defaults.py
@@ -1,8 +1,7 @@
-from pathlib import Path
-
 import pytest
 import xarray as xr
 
+from roms_tools.datasets.download import download_river_tracer_defaults
 from roms_tools.datasets.river_datasets import (
     RECOMMENDED_VALUE_INDEX,
     VALUE_OPTION_DIM,
@@ -23,24 +22,13 @@ def clear_tracer_defaults_cache():
 
 
 @pytest.fixture
-def bundled_defaults_nc():
-    return (
-        Path(__file__).resolve().parents[2]
-        / "datasets"
-        / "data"
-        / "river_tracer_defaults.nc"
-    )
+def tracer_defaults_path():
+    """Path to the river tracer defaults NetCDF, fetched via pooch."""
+    return download_river_tracer_defaults()
 
 
 class TestTracerDefaults:
-    def test_reads_recommended_values_from_bundled_netcdf(
-        self, monkeypatch, bundled_defaults_nc
-    ):
-        monkeypatch.setattr(
-            "roms_tools.datasets.river_datasets.download_river_tracer_defaults",
-            lambda: str(bundled_defaults_nc),
-        )
-
+    def test_reads_recommended_values_from_netcdf(self):
         defaults = get_tracer_defaults()
 
         assert defaults["DIC"] == pytest.approx(1640.071)
@@ -54,8 +42,8 @@ class TestTracerDefaults:
         assert len(defaults) == len(MARBL_TRACER_NAMES)
         assert len(defaults) == 34
 
-    def test_dataclass_exposes_dataset(self, bundled_defaults_nc):
-        data = RiverTracerDefaultsDataset(filename=bundled_defaults_nc)
+    def test_dataclass_exposes_dataset(self, tracer_defaults_path):
+        data = RiverTracerDefaultsDataset(filename=tracer_defaults_path)
 
         assert "DIC" in data.ds
         assert data.ds["DIC"].attrs["units"] == "mmol/m3"
@@ -84,10 +72,10 @@ class TestTracerDefaults:
     def test_recommended_index_is_zero(self):
         assert RECOMMENDED_VALUE_INDEX == 0
 
-    def test_requires_calendar_discharge_time_is_false(self, bundled_defaults_nc):
-        data = RiverTracerDefaultsDataset(filename=bundled_defaults_nc)
+    def test_requires_calendar_discharge_time_is_false(self, tracer_defaults_path):
+        data = RiverTracerDefaultsDataset(filename=tracer_defaults_path)
         assert data.requires_calendar_discharge_time is False
 
-    def test_temporal_interpolation_is_none(self, bundled_defaults_nc):
-        data = RiverTracerDefaultsDataset(filename=bundled_defaults_nc)
+    def test_temporal_interpolation_is_none(self, tracer_defaults_path):
+        data = RiverTracerDefaultsDataset(filename=tracer_defaults_path)
         assert data.temporal_interpolation == "none"

--- a/roms_tools/tests/test_setup/test_tracer_defaults.py
+++ b/roms_tools/tests/test_setup/test_tracer_defaults.py
@@ -79,3 +79,7 @@ class TestTracerDefaults:
     def test_temporal_interpolation_is_none(self, tracer_defaults_path):
         data = RiverTracerDefaultsDataset(filename=tracer_defaults_path)
         assert data.temporal_interpolation == "none"
+
+    def test_fill_value_is_none(self, tracer_defaults_path):
+        data = RiverTracerDefaultsDataset(filename=tracer_defaults_path)
+        assert data.fill_value is None

--- a/roms_tools/tests/test_setup/test_utils.py
+++ b/roms_tools/tests/test_setup/test_utils.py
@@ -360,6 +360,13 @@ class TestMonthlyClimatologyExpansion:
             datetime(2020, m, 15) for m in (1, 2, 3)
         ]
 
+    def test_calendar_midmonth_dates_short_window_without_15th(self):
+        # A sub-month window that skips the 15th must still yield one in-window
+        # date tagged to the correct month, not raise.
+        dates = calendar_midmonth_dates(datetime(2020, 1, 20), datetime(2020, 1, 28))
+        assert dates == [datetime(2020, 1, 20)]
+        assert dates[0].month == 1
+
 
 class TestInterpolateDynamicBGCByCalendarYear:
     @staticmethod


### PR DESCRIPTION
While reviewing #615 I caught one or two incorrect type annotations (in particular, the climatology bool was incorrectly typed as a Dataset and causing my IDE to flag lots of errors). While fixing that, it surfaced some other type annotation errors that existed prior to this branch PR -- fixed those too. 

I embarked on a bit of additional AI-assisted refactoring to remove a lot of the fragile, buried dictionary validation if/elif/elif blocks, and instead surface a few pydantic objects instead that define what these data structures should look like. Happy to talk through some of these changes.

There were also some failing tests that were looking for a river defaults .nc file within the repo -- it looks like this existed at some point, but was removed. Not sure if it was accidental or intentional. There was also a pooch retrieval method so I switch things over to use that, but if the intent was to package the .nc with the repo we can go in that direction instead.

I'm going to push one or two more commits with a few more things Claude is catching, but wanted to get this opened up for awareness.