### PR TITLE
pin xgcm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pyamg",
     "bottleneck",
     "regionmask>=0.11.0",
-    "xgcm>=0.9.0",
+    "xgcm>=0.9.0,<0.10.0",
     "gsw",
     "numba>=0.61.2",
     "pydantic>2,<3",


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
`xgcm` made a 0.10.0 [release](https://github.com/xgcm/xgcm/releases) a few days ago that removes a feature we were using (`periodic` argument to the Grid class). Pinning until we can update.


- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in `docs/api.rst`
- [ ] New functionality has documentation
