### PR TITLE
Xgcm10

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -69,6 +69,7 @@
 * Monthly discharge climatology is expanded to calendar mid-month dates when combined with year-indexed RIVR2O BGC (`expand_monthly_climatology_time_axis`) ([#615](https://github.com/CWorthy-ocean/roms-tools/pull/615))
 * CDR analysis tests cover tonnes-CO2 uptake and renamed efficiency fields; `compute_cdr_metrics` requires `DIC_source` in the input dataset alongside other CDR variables. ([#591](https://github.com/CWorthy-ocean/roms-tools/pull/591))
 * Nesting operations (align_grids and make_nesting_info) now use more efficient gridding techniques
+* Update xgcm API calls to enable support for xgcm>0.10
 
 ### Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pyamg",
     "bottleneck",
     "regionmask>=0.11.0",
-    "xgcm>=0.9.0,<0.10.0",
+    "xgcm>0.10.0",
     "gsw",
     "numba>=0.61.2",
     "pydantic>2,<3",

--- a/roms_tools/regrid.py
+++ b/roms_tools/regrid.py
@@ -436,7 +436,7 @@ class VerticalRegrid:
         self.grid = xgcm.Grid(
             ds,
             coords={source_dim: {"center": source_dim}},
-            periodic=False,
+            padding="fill",
             autoparse_metadata=False,
         )
         self.source_dim = source_dim

--- a/roms_tools/setup/utils.py
+++ b/roms_tools/setup/utils.py
@@ -959,7 +959,7 @@ def compute_mld(
     grid = xgcm.Grid(
         sigma0.to_dataset(name="sigma0"),
         coords={depth_dim: {"center": depth_dim}},
-        periodic=False,
+        padding="fill",
         autoparse_metadata=False,
     )
     with warnings.catch_warnings():

--- a/roms_tools/tests/test_setup/test_river_forcing.py
+++ b/roms_tools/tests/test_setup/test_river_forcing.py
@@ -761,8 +761,9 @@ class TestRiverForcingWithOverlappingIndices:
         # Check no river's volume increased
         for name in ds["river_name"].values:
             river_idx = np.where(ds["river_name"].values == name)[0].item()
-            assert float(ds_out["river_volume"].isel(nriver=river_idx)) <= float(
-                ds["river_volume"].isel(nriver=river_idx)
+            assert (
+                ds_out["river_volume"].isel(nriver=river_idx).item()
+                <= ds["river_volume"].isel(nriver=river_idx).item()
             )
 
         # Check rivers that contribute to overlapping indices have strictly decreased volume
@@ -772,8 +773,9 @@ class TestRiverForcingWithOverlappingIndices:
                 idx in overlapping for idx in idx_list
             ):
                 river_idx = np.where(ds["river_name"].values == name)[0].item()
-                assert float(ds_out["river_volume"].isel(nriver=river_idx)) < float(
-                    ds["river_volume"].isel(nriver=river_idx)
+                assert (
+                    ds_out["river_volume"].isel(nriver=river_idx).item()
+                    < ds["river_volume"].isel(nriver=river_idx).item()
                 )
 
         # Check that total volume is preserved (within tolerance)
@@ -785,7 +787,7 @@ class TestRiverForcingWithOverlappingIndices:
 
         # Check that the synthetic river volume is positive and tracer is not NaN
         synthetic_idx = ds_out.sizes["nriver"] - 1
-        assert float(ds_out["river_volume"].isel(nriver=synthetic_idx)) > 0
+        assert ds_out["river_volume"].isel(nriver=synthetic_idx).item() > 0
         assert not np.isnan(ds_out["river_tracer"].isel(nriver=synthetic_idx).item())
 
     def test_volume_sort_after_overlap(self, mock_river_dataset_with_simple_overlap):


### PR DESCRIPTION
Updates a few xgcm calls to use the new 0.10.0 syntax. Pins xgcm > 0.10 accordingly, undoing the previous defensive pin.

Also includes some unrelated test updates that we breaking under certain versions of numpy.

- [ ] Closes #xxxx
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are documented in `docs/releases.md`
- [ ] New functions/methods are listed in `docs/api.rst`
- [ ] New functionality has documentation
