### PR TITLE
Fix test flakiness

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,10 +13,26 @@ jobs:
     name: ${{ matrix.python-version }}-build (use_dask=False)
     runs-on: ubuntu-latest
     strategy:
+      # Keep the other Python version running when one fails; otherwise the
+      # surviving job is cancelled and its log shows a misleading exit code 143.
+      fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+
+      # A cold pooch cache means ~1.6 GB of timeout-prone downloads from GitHub.
+      # Every job restores; only the full-suite jobs save (so a job running a
+      # subset cannot replace the cache with an incomplete snapshot). The key
+      # tracks the registries in download.py, and restore-keys still reuses the
+      # previous cache, leaving only newly added files to download.
+      - name: Restore pooch data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/roms-tools
+          key: pooch-${{ runner.os }}-${{ hashFiles('roms_tools/datasets/download.py') }}
+          restore-keys: |
+            pooch-${{ runner.os }}-
 
       - name: Create conda environment
         uses: mamba-org/setup-micromamba@v2
@@ -27,10 +43,20 @@ jobs:
           environment-file: ci/environment.yml
           create-args: |
             python=${{ matrix.python-version }}
-          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}
+          # The env-file hash must be in the key, or edits to ci/environment.yml
+          # are silently ignored whenever a cached environment is restored.
+          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('ci/environment.yml') }}
 
       - name: Conda info
         run: conda info
+
+      # All conda jobs build from ci/environment.yml, so verifying here is
+      # enough to prove the serial-ESMF pin took effect. Expect a `nompi_*`
+      # esmf build and no mpich at all.
+      - name: Verify serial (nompi) ESMF build
+        shell: micromamba-shell {0}
+        if: always()
+        run: micromamba list | grep -E "esmf|mpich|hdf5" || true
 
       - name: Install roms-tools
         shell: micromamba-shell {0}
@@ -43,6 +69,15 @@ jobs:
         run: |
            python -V
            coverage run --rcfile=coverage.toml -m pytest --verbose roms_tools/tests/*
+
+      # This job runs the whole suite, so it is the one with a complete set of
+      # data files worth caching. One Python version is enough.
+      - name: Save pooch data cache
+        if: always() && matrix.python-version == '3.13'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/roms-tools
+          key: pooch-${{ runner.os }}-${{ hashFiles('roms_tools/datasets/download.py') }}
 
       - name: Get coverage report
         shell: bash -l {0}
@@ -70,6 +105,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # A cold pooch cache means ~1.6 GB of timeout-prone downloads from GitHub.
+      # Every job restores; only the full-suite jobs save (so a job running a
+      # subset cannot replace the cache with an incomplete snapshot). The key
+      # tracks the registries in download.py, and restore-keys still reuses the
+      # previous cache, leaving only newly added files to download.
+      - name: Restore pooch data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/roms-tools
+          key: pooch-${{ runner.os }}-${{ hashFiles('roms_tools/datasets/download.py') }}
+          restore-keys: |
+            pooch-${{ runner.os }}-
+
       - name: Create conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
@@ -79,7 +127,9 @@ jobs:
           environment-file: ci/environment.yml
           create-args: |
             python=${{ matrix.python-version }}
-          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}
+          # The env-file hash must be in the key, or edits to ci/environment.yml
+          # are silently ignored whenever a cached environment is restored.
+          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('ci/environment.yml') }}
 
       - name: Conda info
         run: conda info
@@ -126,6 +176,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # A cold pooch cache means ~1.6 GB of timeout-prone downloads from GitHub.
+      # Every job restores; only the full-suite jobs save (so a job running a
+      # subset cannot replace the cache with an incomplete snapshot). The key
+      # tracks the registries in download.py, and restore-keys still reuses the
+      # previous cache, leaving only newly added files to download.
+      - name: Restore pooch data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/roms-tools
+          key: pooch-${{ runner.os }}-${{ hashFiles('roms_tools/datasets/download.py') }}
+          restore-keys: |
+            pooch-${{ runner.os }}-
+
       - name: Create conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
@@ -135,7 +198,9 @@ jobs:
           environment-file: ci/environment.yml
           create-args: |
             python=${{ matrix.python-version }}
-          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}
+          # The env-file hash must be in the key, or edits to ci/environment.yml
+          # are silently ignored whenever a cached environment is restored.
+          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('ci/environment.yml') }}
 
       - name: Conda info
         run: conda info
@@ -178,6 +243,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # A cold pooch cache means ~1.6 GB of timeout-prone downloads from GitHub.
+      # Every job restores; only the full-suite jobs save (so a job running a
+      # subset cannot replace the cache with an incomplete snapshot). The key
+      # tracks the registries in download.py, and restore-keys still reuses the
+      # previous cache, leaving only newly added files to download.
+      - name: Restore pooch data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/roms-tools
+          key: pooch-${{ runner.os }}-${{ hashFiles('roms_tools/datasets/download.py') }}
+          restore-keys: |
+            pooch-${{ runner.os }}-
+
       - name: Create conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
@@ -187,7 +265,9 @@ jobs:
           environment-file: ci/environment.yml
           create-args: |
             python=${{ matrix.python-version }}
-          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}
+          # The env-file hash must be in the key, or edits to ci/environment.yml
+          # are silently ignored whenever a cached environment is restored.
+          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('ci/environment.yml') }}
 
       - name: Conda info
         run: conda info
@@ -231,6 +311,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # A cold pooch cache means ~1.6 GB of timeout-prone downloads from GitHub.
+      # Every job restores; only the full-suite jobs save (so a job running a
+      # subset cannot replace the cache with an incomplete snapshot). The key
+      # tracks the registries in download.py, and restore-keys still reuses the
+      # previous cache, leaving only newly added files to download.
+      - name: Restore pooch data cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/roms-tools
+          key: pooch-${{ runner.os }}-${{ hashFiles('roms_tools/datasets/download.py') }}
+          restore-keys: |
+            pooch-${{ runner.os }}-
+
       - name: Create conda environment
         uses: mamba-org/setup-micromamba@v2
         with:
@@ -240,7 +333,9 @@ jobs:
           environment-file: ci/environment.yml
           create-args: |
             python=${{ matrix.python-version }}
-          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}
+          # The env-file hash must be in the key, or edits to ci/environment.yml
+          # are silently ignored whenever a cached environment is restored.
+          cache-environment-key: micromamba-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('ci/environment.yml') }}
 
       - name: Conda info
         run: conda info
@@ -289,6 +384,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # A cold pooch cache means ~1.6 GB of timeout-prone downloads from GitHub.
+      # Every job restores; only the full-suite jobs save (so a job running a
+      # subset cannot replace the cache with an incomplete snapshot). The key
+      # tracks the registries in download.py, and restore-keys still reuses the
+      # previous cache, leaving only newly added files to download.
+      - name: Restore pooch data cache
+        uses: actions/cache/restore@v4
+        with:
+          # pooch.os_cache("roms-tools") -> %LOCALAPPDATA%\roms-tools\roms-tools\Cache
+          # (platformdirs repeats the name because appauthor defaults to appname).
+          path: ~/AppData/Local/roms-tools/roms-tools/Cache
+          key: pooch-${{ runner.os }}-${{ hashFiles('roms_tools/datasets/download.py') }}
+          restore-keys: |
+            pooch-${{ runner.os }}-
+
       - uses: actions/setup-python@v4
         with:
           python-version: "3.12"
@@ -299,8 +409,24 @@ jobs:
            python -V
            python -m pip install -e ".[dev]"
 
+      # The Windows cache path above is hardcoded and cannot be resolved off
+      # Windows; print the real one so a mismatch shows up in the log instead
+      # of silently disabling the cache.
+      - name: Show pooch cache location
+        if: always()
+        shell: bash
+        run: python -c "import pooch; print(pooch.os_cache('roms-tools'))"
+
       - name: Running Tests
         shell: bash
         run: |
            python -V
            pytest --verbose roms_tools/tests
+
+      # The only Windows job, and it runs the whole suite.
+      - name: Save pooch data cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ~/AppData/Local/roms-tools/roms-tools/Cache
+          key: pooch-${{ runner.os }}-${{ hashFiles('roms_tools/datasets/download.py') }}

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -5,4 +5,11 @@ channels:
 dependencies:
   - python>=3.12
   - xesmf  # conda-only (esmpy); the only dependency pip cannot provide
+  # Force the serial (mpiuni) ESMF build. Without this pin conda-forge resolves
+  # esmf to an `mpi_mpich` variant, which drags in MPICH plus MPI-linked
+  # hdf5/libnetcdf. The first xESMF Regridder built in a process then runs
+  # MPI_Init, which on GitHub runners intermittently gets the process killed
+  # (SIGTERM -> "exit code 143"), and the MPI hdf5 also collides with the
+  # serial hdf5 bundled in the pip-installed netcdf4/h5py wheels.
+  - esmf=*=nompi*
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,10 +98,26 @@ requires = [
 fallback_version = "9999"
 
 [tool.setuptools.packages.find]
-exclude = ["docs", "tests", "tests.*", "docs.*"]
+# roms_tools.tests* is excluded so wheels (and installed packages, including the
+# conda-forge build) don't carry the test suite and its ~4400-file zarr fixture
+# tree. The sdist still contains the full tests directory: setuptools_scm
+# includes every git-tracked file there, so tests remain runnable from a source
+# archive or checkout.
+# ci* keeps the release-notes scripts from installing into site-packages as a
+# top-level `ci` package (namespace discovery picks up __init__-less dirs, and
+# roms_tools/{analysis,datasets,tiling} rely on that, so it can't be disabled).
+exclude = ["docs", "tests", "tests.*", "docs.*", "roms_tools.tests", "roms_tools.tests.*", "ci", "ci.*"]
 
 [tool.setuptools.package-data]
 roms_tools = ["py.typed"]
+
+[tool.setuptools.exclude-package-data]
+# Excluding roms_tools.tests* from packages.find (above) is not sufficient on
+# its own: include_package_data (default true) sweeps every git-tracked file
+# under roms_tools/ into the wheel as data of the parent package. This entry
+# keeps the tests out of the wheel too. Only the wheel is affected — the sdist
+# is driven by setuptools_scm's file list and still ships the full tests tree.
+roms_tools = ["tests/**"]
 
 [tool.ruff]
 fix = true

--- a/roms_tools/datasets/download.py
+++ b/roms_tools/datasets/download.py
@@ -1,4 +1,60 @@
+import logging
+import time
+
 import pooch
+
+#: Number of times a download is attempted before the error is raised.
+MAX_DOWNLOAD_ATTEMPTS = 3
+
+#: Seconds to wait before the first retry; doubled for each further attempt.
+RETRY_BACKOFF_SECONDS = 2.0
+
+
+def _fetch(manager: pooch.Pooch, filename: str) -> str:
+    """Fetch a registered file, retrying transient network failures.
+
+    Pooch has no retry logic of its own, so a single dropped connection or a
+    read timeout (30 s by default) against the data repository aborts the whole
+    call. Retries use exponential backoff. Files already in the local cache are
+    never re-downloaded, so a retry only refetches what actually failed.
+
+    The caught type is ``OSError``, which covers every network failure raised
+    here (``requests.exceptions.RequestException`` subclasses it) without
+    importing ``requests``. Local I/O errors are therefore retried too, which
+    only delays an unavoidable failure. A checksum mismatch raises
+    ``ValueError`` and is deliberately not retried, so a bad registry entry
+    fails immediately.
+
+    Parameters
+    ----------
+    manager : pooch.Pooch
+        The Pooch instance the file is registered with.
+    filename : str
+        The name of the file to fetch.
+
+    Returns
+    -------
+    str
+        The path to the file in the local cache.
+    """
+    for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS):
+        try:
+            return manager.fetch(filename)
+        except OSError as error:
+            delay = RETRY_BACKOFF_SECONDS * 2 ** (attempt - 1)
+            logging.warning(
+                "Download of %s failed (attempt %d of %d): %s. Retrying in %.1f s.",
+                filename,
+                attempt,
+                MAX_DOWNLOAD_ATTEMPTS,
+                error,
+                delay,
+            )
+            time.sleep(delay)
+
+    # Final attempt: let the error propagate if this one fails too.
+    return manager.fetch(filename)
+
 
 # Create a Pooch object to manage the global topography data
 topo_data = pooch.create(
@@ -126,7 +182,7 @@ def download_topo(filename: str) -> str:
         The path to the downloaded test data file.
     """
     # Fetch the file using Pooch, downloading if necessary
-    fname = topo_data.fetch(filename)
+    fname = _fetch(topo_data, filename)
 
     return fname
 
@@ -147,7 +203,7 @@ def download_river_data(filename: str) -> str:
         The path to the downloaded file.
     """
     # Fetch the file using Pooch, downloading if necessary
-    fname = river_data.fetch(filename)
+    fname = _fetch(river_data, filename)
 
     return fname
 
@@ -167,7 +223,7 @@ def download_river_tracer_defaults(filename: str = "river_tracer_defaults.nc") -
     str
         The path to the downloaded file.
     """
-    fname = river_data.fetch(filename)
+    fname = _fetch(river_data, filename)
 
     return fname
 
@@ -187,7 +243,7 @@ def download_correction_data(filename: str) -> str:
         The path to the downloaded test data file.
     """
     # Fetch the file using Pooch, downloading if necessary
-    fname = correction_data.fetch(filename)
+    fname = _fetch(correction_data, filename)
 
     return fname
 
@@ -207,7 +263,7 @@ def download_sal_data(filename: str) -> str:
         The path to the downloaded test data file.
     """
     # Fetch the file using Pooch, downloading if necessary
-    fname = sal_data.fetch(filename)
+    fname = _fetch(sal_data, filename)
 
     return fname
 
@@ -244,6 +300,6 @@ def download_test_data(filename: str) -> str:
         The path to the downloaded test data file.
     """
     # Fetch the file using Pooch, downloading if necessary
-    fname = pup_test_data.fetch(filename)
+    fname = _fetch(pup_test_data, filename)
 
     return fname

--- a/roms_tools/tests/test_download.py
+++ b/roms_tools/tests/test_download.py
@@ -1,0 +1,77 @@
+import logging
+
+import pytest
+
+from roms_tools.datasets.download import MAX_DOWNLOAD_ATTEMPTS, _fetch
+
+
+class FakePooch:
+    """Stand-in for ``pooch.Pooch`` that fails a fixed number of times."""
+
+    def __init__(self, failures, error=None):
+        """Fail the first ``failures`` calls with ``error``, then succeed."""
+        self.failures = failures
+        self.error = error or TimeoutError("read timed out")
+        self.calls = 0
+
+    def fetch(self, filename):
+        self.calls += 1
+        if self.calls <= self.failures:
+            raise self.error
+        return f"/cache/{filename}"
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Skip the backoff delays so the tests stay fast."""
+    monkeypatch.setattr("roms_tools.datasets.download.time.sleep", lambda seconds: None)
+
+
+def test_fetch_returns_immediately_when_download_succeeds():
+    manager = FakePooch(failures=0)
+
+    assert _fetch(manager, "etopo5.nc") == "/cache/etopo5.nc"
+    assert manager.calls == 1
+
+
+@pytest.mark.parametrize("failures", range(1, MAX_DOWNLOAD_ATTEMPTS))
+def test_fetch_retries_transient_network_errors(failures, caplog):
+    manager = FakePooch(failures=failures)
+
+    with caplog.at_level(logging.WARNING):
+        assert _fetch(manager, "etopo5.nc") == "/cache/etopo5.nc"
+
+    assert manager.calls == failures + 1
+    assert len(caplog.records) == failures
+
+
+def test_fetch_retries_the_error_seen_in_ci():
+    """`requests` errors subclass `OSError`, which is what the retry catches."""
+    # Imported here rather than at module scope: requests is only present as a
+    # transitive dependency of pooch, and roms-tools does not import it.
+    import requests
+
+    manager = FakePooch(
+        failures=1, error=requests.exceptions.ReadTimeout("read timed out")
+    )
+
+    assert _fetch(manager, "etopo5.nc") == "/cache/etopo5.nc"
+    assert manager.calls == 2
+
+
+def test_fetch_raises_after_exhausting_attempts():
+    manager = FakePooch(failures=MAX_DOWNLOAD_ATTEMPTS)
+
+    with pytest.raises(TimeoutError):
+        _fetch(manager, "etopo5.nc")
+
+    assert manager.calls == MAX_DOWNLOAD_ATTEMPTS
+
+
+def test_fetch_does_not_retry_checksum_mismatch():
+    manager = FakePooch(failures=1, error=ValueError("hash mismatch"))
+
+    with pytest.raises(ValueError):
+        _fetch(manager, "etopo5.nc")
+
+    assert manager.calls == 1


### PR DESCRIPTION
# Summary
<!-- Feel free to remove sections irrelevant to this PR or leave the default `N/A` content -->

## Breaking Changes
<!-- List any breaking changes to interfaces, changes to inputs or outputs, or procedural changes -->
- N/A

## New Features
<!-- List any new capabilities added -->
- N/A

## Bug Fixes
<!-- List any behavioral changes resulting from pre-existing code performing in an unexpected manner  -->
- N/A

## Improvements
<!-- List any improvements made to existing code or processes  -->
- N/A

## Miscellaneous
<!-- List any non-code-related changes, such as CI, packaging, or documentation -->
- Fix test flakiness (exit code 143) from MPI-flavored esmf installations
- Use a github cache for pooch data to speed up CI and avoid network errors
- Exclude test files from packaged wheel to increase build speed and reduce package size


## Code Review Checklist
<!-- Feel free to remove check-list items irrelevant to this PR -->
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing
