### PR TITLE
Auto-publish tagged GitHub release when the finalize-notes PR merges

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,0 +1,119 @@
+name: Publish Release
+
+# Auto-creates the tagged GitHub release when the "Finalize release notes for
+# <tag>" PR (opened by finalize_release_notes.yaml from the next_release_notes
+# branch) is merged into main. The release body is the curated notes we just
+# merged, extracted by ci/release_body.py.
+#
+# The release is created with a Personal Access Token (secrets.RELEASE_PAT),
+# NOT the default GITHUB_TOKEN: releases created by GITHUB_TOKEN do not fire
+# `on: release` workflows, which would silently skip PyPI trusted publishing
+# (pypipublish.yaml). A PAT-created release cascades normally.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  publish-release:
+    # Only the finalize-release-notes PR, and only when actually merged.
+    # head.ref == next_release_notes is the unique signal: finalize_release_notes.yaml
+    # is the only workflow that opens a PR from that branch into main. The
+    # head.repo == base.repo check rejects a look-alike PR opened from a fork
+    # (defense in depth — fork PRs also get no secrets, so RELEASE_PAT is empty).
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'next_release_notes' &&
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
+      startsWith(github.event.pull_request.title, 'Finalize release notes for ')
+    runs-on: ubuntu-latest
+    # Serialize duplicate webhook deliveries / manual re-runs for the same PR so
+    # the "release already exists?" check and the create step cannot race.
+    concurrency:
+      group: publish-release-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    # Note: this job creates the release with RELEASE_PAT, not GITHUB_TOKEN, so
+    # this permissions block does not bound its writes — scope RELEASE_PAT itself
+    # to `contents: write` on these repos. It is kept for correctness of any
+    # future GITHUB_TOKEN use.
+    permissions:
+      contents: write
+
+    steps:
+      - name: Guard against a missing merge commit
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          if [ -z "$MERGE_SHA" ]; then
+            echo "::error::merge_commit_sha is empty — cannot target the release."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          # Check out the exact merge commit, not `main`: another PR could merge
+          # between this event and the checkout, and the release must target the
+          # tree whose release notes we are publishing.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          # PAT so the created release cascades to on:release workflows (see header).
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Derive and validate release tag
+        id: tag
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          raw="${PR_TITLE#Finalize release notes for }"
+          # Standardized convention: tags have no leading v (e.g. 0.5.0).
+          tag="$(printf '%s' "$raw" | tr -d '`[:space:]')"
+          tag="${tag#v}"
+          tag="${tag#V}"
+          if ! printf '%s' "$tag" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)*$'; then
+            echo "::error::Could not parse a semver tag from PR title: '$PR_TITLE'"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Derived release tag: $tag"
+
+      - name: Cross-check tag against finalized release notes
+        # Fails loudly if the PR title disagrees with the newest finalized
+        # release in the docs (retitled PR, or finalize didn't actually run).
+        run: python ci/release_body.py "${{ steps.tag.outputs.tag }}" --check-only
+
+      - name: Skip if the release already exists
+        id: exists
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if gh release view "${{ steps.tag.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Release ${{ steps.tag.outputs.tag }} already exists — nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release body from finalized notes
+        if: steps.exists.outputs.skip == 'false'
+        run: python ci/release_body.py "${{ steps.tag.outputs.tag }}" > "$RUNNER_TEMP/release_body.md"
+
+      - name: Create the GitHub release
+        if: steps.exists.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          # To also append GitHub's auto-generated contributor list below the
+          # curated notes, add: --generate-notes
+          gh release create "$TAG" \
+            --target "$MERGE_SHA" \
+            --title "$TAG" \
+            --notes-file "$RUNNER_TEMP/release_body.md"

--- a/.github/workflows/update_release_notes.yaml
+++ b/.github/workflows/update_release_notes.yaml
@@ -8,8 +8,12 @@ on:
 
 jobs:
   update-release-notes:
-    # Only run when the PR was actually merged, not just closed
-    if: github.event.pull_request.merged == true
+    # Only run when the PR was actually merged, not just closed — and never for
+    # the finalize PR itself (from next_release_notes), whose merge is handled by
+    # publish_release.yaml; otherwise this would re-open a fresh Unreleased block.
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref != 'next_release_notes'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/ci/release_body.py
+++ b/ci/release_body.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Print the Markdown release-notes body for a finalized release *tag*.
+
+Slices the ``## <tag>`` section out of ``docs/releases.md`` (from that heading
+down to the next ``## `` heading), drops the heading line itself — the GitHub
+release title already shows the tag — and prints the remainder to stdout, ready
+for ``gh release create --notes-file``. The content is already GitHub-flavored
+Markdown, so no conversion is needed.
+
+With ``--check-only`` nothing is printed; instead the tag is validated as the
+newest real release section in the file (any leading ``Unreleased`` block is
+ignored), exiting non-zero on mismatch. This guards the publish workflow
+against a retitled PR or a finalize step that never ran.
+
+Release tags are stored without a leading ``v`` (e.g. ``0.5.0``); a ``v``-prefix
+on the argument or in a heading is stripped before comparison.
+
+Usage:
+    python ci/release_body.py <tag> [--check-only]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+RELEASES_MD = Path(__file__).resolve().parent.parent / "docs" / "releases.md"
+
+_H2_RE = re.compile(r"^##\s+(.+?)\s*$")
+
+
+def normalize_tag(tag: str) -> str:
+    """Strip a leading ``v``/``V`` from *tag* if present (``v0.5.0`` -> ``0.5.0``)."""
+    return tag[1:] if re.match(r"^[vV]\d", tag) else tag
+
+
+def _is_unreleased(title: str) -> bool:
+    """Return True if a ``## `` heading title marks an in-development block."""
+    low = title.strip().lower()
+    return low == "unreleased" or "(unreleased)" in low
+
+
+def iter_sections(lines: list[str]) -> list[tuple[str, int, int]]:
+    """
+    Return ``(title, start_idx, end_idx)`` for every ``## `` section in *lines*.
+
+    ``start_idx`` is the heading line; ``end_idx`` is the next ``## `` heading
+    or end of file. A ``## `` inside a fenced code block (```` ``` ````) is a
+    code sample, not a heading, and is ignored.
+    """
+    heads: list[tuple[int, str]] = []
+    in_fence = False
+    for i, ln in enumerate(lines):
+        if ln.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        m = _H2_RE.match(ln)
+        if m:
+            heads.append((i, m.group(1).strip()))
+    out: list[tuple[str, int, int]] = []
+    for n, (i, title) in enumerate(heads):
+        end = heads[n + 1][0] if n + 1 < len(heads) else len(lines)
+        out.append((title, i, end))
+    return out
+
+
+def section_body(tag: str) -> str:
+    """
+    Return the Markdown body of the ``## <tag>`` section, heading excluded.
+
+    Raises ``SystemExit`` if no matching section exists.
+    """
+    tag = normalize_tag(tag)
+    lines = RELEASES_MD.read_text().splitlines(keepends=True)
+    for title, start, end in iter_sections(lines):
+        if normalize_tag(title) == tag:
+            body = "".join(lines[start + 1 : end]).strip("\n")
+            if not body.strip():
+                sys.exit(f"Release section '## {tag}' in {RELEASES_MD} is empty.")
+            return body + "\n"
+    sys.exit(f"No release section '## {tag}' found in {RELEASES_MD}")
+
+
+def check_newest(tag: str) -> None:
+    """
+    Validate that *tag* is the newest real (non-``Unreleased``) release section.
+
+    Raises ``SystemExit`` if the file has no release sections, or the newest
+    real section is some other version.
+    """
+    tag = normalize_tag(tag)
+    lines = RELEASES_MD.read_text().splitlines(keepends=True)
+    real = [t for t, _, _ in iter_sections(lines) if not _is_unreleased(t)]
+    if not real:
+        sys.exit(f"No release sections found in {RELEASES_MD}")
+    newest = normalize_tag(real[0])
+    if newest != tag:
+        sys.exit(
+            f"Tag '{tag}' is not the newest release section in "
+            f"{RELEASES_MD.name} (top of file is '{newest}')."
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Emit release-notes body for a tag.")
+    parser.add_argument("tag", help="Release tag, e.g. 0.5.0")
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Validate the tag is the newest release section; print nothing.",
+    )
+    args = parser.parse_args()
+
+    if args.check_only:
+        check_newest(args.tag)
+        return
+    sys.stdout.write(section_body(args.tag))
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/test_release_body.py
+++ b/ci/test_release_body.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for ``release_body.py`` (Markdown release-notes extraction).
+
+This ``ci/`` script has no existing pytest CI wiring in this repo; run
+directly with::
+
+    pytest ci/test_release_body.py
+
+Covers the two guarantees the publish workflow relies on: the emitted body is
+exactly the tag's section with the heading stripped, and ``check_newest``
+accepts the newest real release (ignoring any leading ``Unreleased`` block)
+while rejecting anything else.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "release_body",
+    Path(__file__).resolve().parent / "release_body.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+_RELEASES = (
+    "# Release notes\n"
+    "\n"
+    "## Unreleased\n"
+    "\n"
+    "### New Features\n"
+    "\n"
+    "* Work in progress ([#99](https://example/pull/99))\n"
+    "\n"
+    "## 0.5.0\n"
+    "\n"
+    "### Breaking Changes\n"
+    "\n"
+    "* Requires cstar-ocean 0.11.0 ([#137](https://example/pull/137))\n"
+    "\n"
+    "### Bug Fixes\n"
+    "\n"
+    "* Fixed a thing ([#121](https://example/pull/121))\n"
+    "\n"
+    "## 0.4.0\n"
+    "\n"
+    "### New Features\n"
+    "\n"
+    "* Older feature ([#113](https://example/pull/113))\n"
+)
+
+
+@pytest.fixture
+def releases_file(tmp_path, monkeypatch):
+    path = tmp_path / "releases.md"
+    path.write_text(_RELEASES)
+    monkeypatch.setattr(_MODULE, "RELEASES_MD", path)
+    return path
+
+
+def test_section_body_strips_heading_and_stops_at_next_section(releases_file):
+    body = _MODULE.section_body("0.5.0")
+    assert body == (
+        "### Breaking Changes\n"
+        "\n"
+        "* Requires cstar-ocean 0.11.0 ([#137](https://example/pull/137))\n"
+        "\n"
+        "### Bug Fixes\n"
+        "\n"
+        "* Fixed a thing ([#121](https://example/pull/121))\n"
+    )
+    # Neither the Unreleased block above nor the 0.4.0 block below leaks in.
+    assert "Unreleased" not in body
+    assert "0.4.0" not in body and "Older feature" not in body
+
+
+def test_section_body_accepts_v_prefix(releases_file):
+    assert _MODULE.section_body("v0.5.0") == _MODULE.section_body("0.5.0")
+
+
+def test_section_body_missing_tag_exits(releases_file):
+    with pytest.raises(SystemExit):
+        _MODULE.section_body("9.9.9")
+
+
+def test_check_newest_ignores_unreleased(releases_file):
+    # 0.5.0 is the newest *real* section even though Unreleased sits above it.
+    _MODULE.check_newest("0.5.0")
+
+
+def test_check_newest_rejects_stale_tag(releases_file):
+    with pytest.raises(SystemExit):
+        _MODULE.check_newest("0.4.0")
+
+
+def test_normalize_tag():
+    assert _MODULE.normalize_tag("v0.5.0") == "0.5.0"
+    assert _MODULE.normalize_tag("0.5.0") == "0.5.0"
+
+
+def test_heading_inside_fenced_code_block_is_not_a_section(tmp_path, monkeypatch):
+    path = tmp_path / "releases.md"
+    path.write_text(
+        "# Release notes\n"
+        "\n"
+        "## 0.5.0\n"
+        "\n"
+        "### New Features\n"
+        "\n"
+        "* Example config:\n"
+        "\n"
+        "  ```yaml\n"
+        "  ## not a heading, just a comment in a code block\n"
+        "  key: value\n"
+        "  ```\n"
+        "\n"
+        "* Another real note\n"
+        "\n"
+        "## 0.4.0\n"
+        "\n"
+        "### New Features\n"
+        "\n"
+        "* Older\n"
+    )
+    monkeypatch.setattr(_MODULE, "RELEASES_MD", path)
+    body = _MODULE.section_body("0.5.0")
+    # The whole 0.5.0 section survives; the fenced '## ' did not split it.
+    assert "Another real note" in body
+    assert "key: value" in body
+    # And it still stops at the real 0.4.0 heading.
+    assert "Older" not in body
+
+
+def test_empty_section_body_exits(tmp_path, monkeypatch):
+    path = tmp_path / "releases.md"
+    path.write_text("# Release notes\n\n## 0.5.0\n\n## 0.4.0\n\nolder\n")
+    monkeypatch.setattr(_MODULE, "RELEASES_MD", path)
+    with pytest.raises(SystemExit):
+        _MODULE.section_body("0.5.0")


### PR DESCRIPTION
# Summary

Automates the last manual step of the release process. Today, after the **Finalize Release Notes** PR is reviewed and merged, a maintainer manually creates the GitHub release — tagging main, titling it with the semver, and letting GitHub auto-generate notes (which are less descriptive than the ones we just curated). This PR adds a `Publish Release` workflow that fires when that finalize PR merges and does it automatically: it creates the tag and release on the new `main`, titles the release with the semver, and sets the release body to the **curated notes we just merged** (not GitHub's auto-generated summary).

## Miscellaneous
- The tagged GitHub release is now created automatically when the "Finalize release notes for `<tag>`" PR is merged, using the release notes just finalized in the docs as the release body — instead of the manual tag-and-publish step with GitHub's weaker auto-generated summary.
- Merging the release-notes finalization PR no longer causes the release-notes updater to re-open a spurious "Unreleased" section.

## Code Review Checklist
- [ ] Closes #xxxx
- [ ] New functionality has documentation, type hint coverage, and tests
- [ ] Tests and `pre-commit run --all-files` are passing