### PR TITLE
Fix RiverForcing.from_yaml for domain edge cases

### DIFF
--- a/roms_tools/setup/river_forcing.py
+++ b/roms_tools/setup/river_forcing.py
@@ -38,6 +38,7 @@ from roms_tools.setup.utils import (
     add_time_info_to_ds,
     add_tracer_metadata_to_ds,
     expand_monthly_climatology_time_axis,
+    find_coastal_cells,
     from_yaml,
     get_target_coords,
     get_tracer_defaults,
@@ -1204,14 +1205,10 @@ class RiverForcing:
         else:
             river_lon = np.where(river_lon < 0, river_lon + 360, river_lon)
 
-        # Identify coastal grid cells — land cells adjacent to ocean.
-        mask = self.grid.ds.mask_rho.values  # (eta_rho, xi_rho)
-        faces = np.zeros_like(mask)
-        faces[1:, :] += mask[:-1, :]  # south neighbor
-        faces[:-1, :] += mask[1:, :]  # north neighbor
-        faces[:, 1:] += mask[:, :-1]  # west neighbor
-        faces[:, :-1] += mask[:, 1:]  # east neighbor
-        coast = (1 - mask) * (faces > 0)
+        # Identify coastal grid cells — land cells adjacent to ocean. Must use the
+        # same definition as check_river_locations_are_along_coast so that a
+        # YAML round-trip accepts every location chosen here.
+        coast = find_coastal_cells(self.grid.ds.mask_rho.values)
 
         # Get eta, xi indices and lat/lon of coastal cells
         coast_eta, coast_xi = np.where(coast)
@@ -1988,13 +1985,12 @@ def check_river_locations_are_along_coast(mask, indices):
     ValueError
         If any river is not located on the coast.
     """
-    faces = (
-        mask.shift(eta_rho=1)
-        + mask.shift(eta_rho=-1)
-        + mask.shift(xi_rho=1)
-        + mask.shift(xi_rho=-1)
-    )
-    coast = (1 - mask) * (faces > 0)
+    # Use the same coast definition as the auto-discovery path
+    # (find_coastal_cells). The previous xarray ``shift``-based implementation
+    # produced NaN along the domain edges, so edge cells were never counted as
+    # coast and RiverForcing.from_yaml rejected rivers that the auto-discovery
+    # path had legitimately placed there.
+    coast = find_coastal_cells(np.asarray(mask))
 
     for key, river_data in indices.items():
         for idx_pair in river_data:

--- a/roms_tools/tests/test_setup/test_river_forcing.py
+++ b/roms_tools/tests/test_setup/test_river_forcing.py
@@ -22,8 +22,9 @@ from roms_tools.setup.river_forcing import (
     _climatological_river_temp,
     _sample_tair_at_river_mouths,
     _smooth_and_floor_air_temp,
+    check_river_locations_are_along_coast,
 )
-from roms_tools.setup.utils import get_tracer_defaults
+from roms_tools.setup.utils import find_coastal_cells, get_tracer_defaults
 from roms_tools.tests.river_test_utils import write_glofas_file
 from roms_tools.tests.rivr2o_test_utils import write_rivr2o_file
 
@@ -362,14 +363,7 @@ class TestRiverForcingGeneral:
     def test_river_locations_are_along_coast(self, river_forcing_fixture, request):
         river_forcing = request.getfixturevalue(river_forcing_fixture)
 
-        mask = river_forcing.grid.ds.mask_rho
-        faces = (
-            mask.shift(eta_rho=1)
-            + mask.shift(eta_rho=-1)
-            + mask.shift(xi_rho=1)
-            + mask.shift(xi_rho=-1)
-        )
-        coast = (1 - mask) * (faces > 0)
+        coast = find_coastal_cells(river_forcing.grid.ds.mask_rho.values)
 
         indices = river_forcing.indices
         for name in indices.keys():
@@ -657,6 +651,52 @@ class TestRiverForcingWithPrescribedIndices:
                 end_time=self.end_time,
                 indices=indices,
             )
+
+
+class TestCheckRiverLocationsAreAlongCoast:
+    """The coast check on the ``from_yaml`` path must agree with the coast
+    definition used by auto-discovery (``find_coastal_cells``), including at
+    the domain edges.
+    """
+
+    @pytest.fixture
+    def mask(self):
+        # Land column along the western edge (xi_rho=0) and a land island
+        # in the interior; everything else is ocean.
+        m = np.ones((6, 6))
+        m[:, 0] = 0
+        m[2:4, 2:4] = 0
+        return xr.DataArray(m, dims=("eta_rho", "xi_rho"))
+
+    def test_accepts_coastal_cell_on_domain_edge(self, mask):
+        # Regression: a river snapped to the domain-edge land column by
+        # auto-discovery used to be rejected when reloaded via from_yaml.
+        check_river_locations_are_along_coast(mask, {"edge_river": [(3, 0)]})
+
+    def test_accepts_interior_coastal_cell(self, mask):
+        check_river_locations_are_along_coast(mask, {"island": [(2, 2)]})
+
+    def test_rejects_ocean_cell(self, mask):
+        with pytest.raises(ValueError, match="not located on the coast"):
+            check_river_locations_are_along_coast(mask, {"ocean": [(0, 5)]})
+
+    def test_rejects_inland_cell(self):
+        m = np.ones((7, 7))
+        m[1:6, 1:6] = 0  # 5x5 land block; (3, 3) is land with no ocean neighbor
+        mask = xr.DataArray(m, dims=("eta_rho", "xi_rho"))
+        with pytest.raises(ValueError, match="not located on the coast"):
+            check_river_locations_are_along_coast(mask, {"inland": [(3, 3)]})
+
+    def test_matches_find_coastal_cells_everywhere(self, mask):
+        coast = find_coastal_cells(mask.values)
+        for eta in range(mask.sizes["eta_rho"]):
+            for xi in range(mask.sizes["xi_rho"]):
+                idx = {"r": [(eta, xi)]}
+                if coast[eta, xi]:
+                    check_river_locations_are_along_coast(mask, idx)
+                else:
+                    with pytest.raises(ValueError):
+                        check_river_locations_are_along_coast(mask, idx)
 
 
 class TestRiverForcingWithOverlappingIndices:


### PR DESCRIPTION
# Summary

`RiverForcing.from_yaml` could fail with `River <name> is not located on the coast at grid cell (eta, 0)` when re-loading a YAML that `RiverForcing` itself had written. Auto-discovery and the re-load validation used two different definitions of "coastal cell" that disagreed along the outermost row/column of the grid: the auto-discovery path (via `find_coastal_cells`) counts an edge land cell as coast if any in-grid neighbor is ocean, while the re-load check rebuilt the coast with xarray `shift`, which fills the edges with NaN and therefore never counted edge cells as coast. Rivers just outside the domain (pulled in by the default `domain_edge_buffer`) get snapped to the edge column, serialize faithfully, and were then rejected on re-load. Both paths now share the single `find_coastal_cells` definition. Generated forcing output is unchanged; only the re-load validation is corrected.

## Breaking Changes
- N/A

## New Features
- N/A

## Bug Fixes
- `RiverForcing.from_yaml` no longer rejects rivers that auto-discovery placed on a coastal cell along the domain edge, so YAML files written by `RiverForcing` always round-trip.

## Improvements
- N/A

## Miscellaneous
- N/A

## Notes for Reviewers
- The fix keeps rivers on the outermost rho row/column, which is where ROMS applies open boundary conditions. If discharging into a boundary cell is undesirable, the right follow-up is to exclude edge cells in `find_coastal_cells` so auto-discovery snaps to the nearest interior coast instead. That would change scientific output and is deliberately out of scope here.
- `_move_rivers_to_closest_coast` had its own hand-rolled numpy copy of the coast logic (numerically identical to `find_coastal_cells`); it now calls the shared helper so there is exactly one definition.
- New `TestCheckRiverLocationsAreAlongCoast` covers edge, interior, ocean, and inland cells and asserts the check agrees with `find_coastal_cells` at every cell of a small mask. The existing `test_river_locations_are_along_coast` was also switched to the shared helper.

## Code Review Checklist
- [ ] Closes #xxxx
- [x] New functionality has documentation, type hint coverage, and tests
- [x] Tests and `pre-commit run --all-files` are passing (full `test_river_forcing.py`: 106 passed, 1 skipped; pre-commit run on the two touched files)
